### PR TITLE
Support for XML encoded in a string function argument, and for XML encoded in a string return value

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mimeparse": "*",
     "regex-parser": "^2.2.1",
     "soap": "^0.13.0",
+    "xml2js": "^0.4.16",
     "xmlbuilder": "^7.0.0"
   },
   "devDependencies": {

--- a/spec/soap-encoded.xml
+++ b/spec/soap-encoded.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <AddLeadResponse xmlns="http://donkey/ws.asmx/">
+            <AddLeadXMLResult>
+                &lt;Response&gt;
+                    &lt;Result&gt;true&lt;/Result&gt;
+                    &lt;Message&gt;some message&lt;/Message&gt;
+                    &lt;LeadId&gt;12345&lt;/LeadId&gt;
+                    &lt;Empty/&gt;
+                    &lt;Multi&gt;
+                        &lt;Foo&gt;1&lt;/Foo&gt;
+                        &lt;Foo&gt;2&lt;/Foo&gt;
+                    &lt;/Multi&gt;
+                &lt;/Response&gt;
+            </AddLeadXMLResult>
+        </AddLeadResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/spec/soap-wsdl.xml
+++ b/spec/soap-wsdl.xml
@@ -638,6 +638,21 @@
                     <s:element minOccurs="1" maxOccurs="1" name="LeadId" type="s:int" />
                 </s:sequence>
             </s:complexType>
+
+            <s:element name="AddLeadXML">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="LeadXML" nillable="true" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="AddLeadXMLResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="AddLeadXMLResult" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
             <s:element name="AddLeadLog">
                 <s:complexType>
                     <s:sequence>
@@ -945,6 +960,12 @@
     <wsdl:message name="AddLeadSoapOut">
         <wsdl:part name="parameters" element="tns:AddLeadResponse" />
     </wsdl:message>
+    <wsdl:message name="AddLeadXMLSoapIn">
+        <wsdl:part name="parameters" element="tns:AddLeadXML" />
+    </wsdl:message>
+    <wsdl:message name="AddLeadXMLSoapOut">
+        <wsdl:part name="parameters" element="tns:AddLeadXMLResponse" />
+    </wsdl:message>
     <wsdl:message name="AddLeadLogSoapIn">
         <wsdl:part name="parameters" element="tns:AddLeadLog" />
     </wsdl:message>
@@ -1029,6 +1050,10 @@
         <wsdl:operation name="AddLead">
             <wsdl:input message="tns:AddLeadSoapIn" />
             <wsdl:output message="tns:AddLeadSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="AddLeadXML">
+            <wsdl:input message="tns:AddLeadXMLSoapIn" />
+            <wsdl:output message="tns:AddLeadXMLSoapOut" />
         </wsdl:operation>
         <wsdl:operation name="AddLeadLog">
             <wsdl:input message="tns:AddLeadLogSoapIn" />
@@ -1177,6 +1202,15 @@
         </wsdl:operation>
         <wsdl:operation name="AddLead">
             <soap:operation soapAction="http://donkey/ws.asmx/AddLead" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="AddLeadXML">
+            <soap:operation soapAction="http://donkey/ws.asmx/AddLeadXML" style="document" />
             <wsdl:input>
                 <soap:body use="literal" />
             </wsdl:input>
@@ -1351,6 +1385,15 @@
         </wsdl:operation>
         <wsdl:operation name="AddLead">
             <soap12:operation soapAction="http://donkey/ws.asmx/AddLead" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="AddLeadXML">
+            <soap12:operation soapAction="http://donkey/ws.asmx/AddLeadXML" style="document" />
             <wsdl:input>
                 <soap12:body use="literal" />
             </wsdl:input>

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -33,6 +33,21 @@ describe 'Outbound XML request', ->
       'Bar': 'baz'
 
 
+  it 'should handle empty xml path', ->
+    vars = xml_path: {}
+    assert.equal integration.request(vars).body, '<?xml version="1.0"?>'
+
+
+  it 'should handle undefined xml path', ->
+    vars = {}
+    assert.equal integration.request(vars).body, '<?xml version="1.0"?>'
+
+
+  it 'should handle null xml path', ->
+    vars = xml_path: undefined
+    assert.equal integration.request(vars).body, '<?xml version="1.0"?>'
+
+
   it 'should support simple dot-notation', ->
     vars =
       xml_path:

--- a/src/xml-doc.coffee
+++ b/src/xml-doc.coffee
@@ -1,0 +1,30 @@
+_ = require('lodash')
+flat = require('flat')
+normalize = require('./normalize')
+
+
+#
+# Convert an object into one that can be used by xmlbuilder to create a XML document.
+# Keys containing @ are treated as attributes.
+#
+module.exports = (obj) ->
+
+  xmlPaths = flat.flatten(normalize(obj))
+
+  xmlPaths =
+    _(xmlPaths)
+
+    # Keys that contain neither @ nor # are added as element text
+    .mapKeys (value, key) ->
+      if key.match(/@|#/)
+        key
+      else
+        "#{key}#text"
+
+    # The @ or # should be treated as nested values
+    .mapKeys (value, key) ->
+      key.replace(/(@|#)/, '.$1')
+
+    .value()
+
+  flat.unflatten(xmlPaths)

--- a/src/xml.coffee
+++ b/src/xml.coffee
@@ -1,7 +1,7 @@
 _ = require('lodash')
 querystring = require('querystring')
 builder = require('xmlbuilder')
-flat = require('flat')
+xmlDoc = require('./xml-doc')
 response = require('./response')
 validate = require('./validate')
 normalize = require('./normalize')
@@ -16,25 +16,12 @@ headers = require('./headers')
 
 request = (vars) ->
 
-  xmlPaths = flat.flatten(normalize(vars.xml_path))
-
-  xmlPaths =
-    _(xmlPaths)
-
-      # Keys that don't contain @ or # are added as element text
-      .mapKeys (value, key) ->
-        if key.match(/@|#/)
-          key
-        else
-          "#{key}#text"
-
-      # The @ or # should be treated as nested values
-      .mapKeys (value, key) ->
-        key.replace(/(@|#)/, '.$1')
-
-      .value()
-
-  body = builder.create(flat.unflatten(xmlPaths)).end(pretty: true)
+  obj = xmlDoc(vars.xml_path)
+  body =
+    if Object.keys(obj).length
+      builder.create(obj).end(pretty: true)
+    else
+      '<?xml version="1.0"?>'
 
   contentType = 'text/xml'
 


### PR DESCRIPTION
This adds support for SOAP services that expect an XML string, rather than an object, passed as the function argument. It also supports services that return an XML string rather than an object.

These are non-standard methods of operation, but are prevalent enough that we should add first-class support for them. 