### PR TITLE
Json in parameter

### DIFF
--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -94,7 +94,23 @@ describe 'Outbound JSON request', ->
 
     assert.equal integration.request(vars).body, '{"number":"foo"}'
 
+  it 'should stuff JSON into url-encoded body parameter and include any additional parameters', ->
+    vars =
+      json_property:
+        postal_code: types.postal_code.parse('78704')
+        phone: types.phone.parse('512-789-1111 x123')
+        boolean: types.boolean.parse('T')
+        gender: types.gender.parse('F')
+        number: types.number.parse('$100,000.00')
+        range: types.range.parse('1,000-2,000')
+      json_parameter: 'element'
+      extra_parameter:
+        'sessionName': 'asdf1234asdf1234'
+        'operation': 'create'
+        'elementType': 'lead'
 
+    assert.equal integration.request(vars).headers['Content-Type'], 'application/x-www-form-urlencoded'
+    assert.equal integration.request(vars).body, 'element=%7B%22postal_code%22%3A%2278704%22%2C%22phone%22%3A%225127891111x123%22%2C%22boolean%22%3Atrue%2C%22gender%22%3A%22female%22%2C%22number%22%3A100000%2C%22range%22%3A%221000-2000%22%7D&sessionName=asdf1234asdf1234&operation=create&elementType=lead'
 
 
 describe 'JSON validation', ->

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -1,4 +1,6 @@
 _ = require('lodash')
+querystring = require('querystring')
+flat = require('flat')
 response = require('./response')
 validate = require('./validate')
 normalize = require('./normalize')
@@ -19,6 +21,16 @@ request = (vars) ->
     'Content-Length': body.length
     'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'
 
+  if vars.json_parameter
+    b = {}
+    b[vars.json_parameter] = body
+    body = querystring.stringify(b)
+    if vars.extra_parameter
+      params = flat.flatten(normalize(vars.extra_parameter), safe:true)
+      body = querystring.stringify(_.merge(b,params))
+    defaultHeaders['Content-Type'] = 'application/x-www-form-urlencoded'
+    defaultHeaders['Content-Length'] = Buffer.byteLength(body)
+
   url: vars.url
   method: vars.method?.toUpperCase() ? 'POST'
   headers: _.merge defaultHeaders, headers(vars.header)
@@ -35,6 +47,8 @@ request.variables = ->
     { name: 'url', description: 'Server URL', type: 'string', required: true }
     { name: 'method', description: 'HTTP method (POST, PUT, or DELETE)', type: 'string', required: true }
     { name: 'json_property.*', description: 'JSON property in dot notation', type: 'wildcard', required: false }
+    { name: 'json_parameter', description: 'To "stuff" the JSON into a parameter and send as Form URL encoded, specify the parameter name', type: 'string', required: false }
+    { name: 'extra_parameter.*', description: 'Extra parameters to include in URL, only used when JSON Parameter is set', type: 'wildcard', required: false }
   ].concat(variables)
 
 

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -18,7 +18,7 @@ request = (vars) ->
 
   defaultHeaders =
     'Content-Type': 'application/json; charset=utf-8'
-    'Content-Length': body.length
+    'Content-Length': Buffer.byteLength(body)
     'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'
 
   if vars.json_parameter


### PR DESCRIPTION
This PR implements the same "to-parameter" features that the XML integration has for the JSON integration:

  * Stuffing the JSON body into a url encoded parameter
  * including any additional parameters specified by the user

The impetus for this feature is that the vTiger CRM's API expects JSON chunks in parameters of url-encoded bodies.

Let me know if you have any questions or comments.