### PR TITLE
Support a 'root' array in the custom JSON integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.3] - 2016-08-25
+### Fixed
+- When all `json_property` values have a leading digit, assume the user wants a root array.
+
 ## [2.8.2] - 2016-07-09
 ### Fixed
 - add `send_ascii` to SOAP integrations request variables

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -142,6 +142,15 @@ describe 'Outbound JSON request', ->
     assert.equal integration.request(vars).body, '[{"foo":{"bar":"baz"}},{"foo":{"bip":"bap","bar":"bip"}}]'
 
 
+  it 'should build array with missing index', ->
+    vars =
+      json_property:
+        '0.foo.bar': 'baz'
+        '2.foo.bip': 'bap'
+        '2.foo.bar': 'bip'
+    assert.equal integration.request(vars).body, '[{"foo":{"bar":"baz"}},null,{"foo":{"bip":"bap","bar":"bip"}}]'
+
+
   it 'should build object even though a json property has a leading digit', ->
     vars =
       json_property:

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -133,6 +133,24 @@ describe 'Outbound JSON request', ->
     assert.equal integration.request(vars).body, 'element=%7B%22postal_code%22%3A%2278704%22%2C%22phone%22%3A%225127891111x123%22%2C%22boolean%22%3Atrue%2C%22gender%22%3A%22female%22%2C%22number%22%3A100000%2C%22range%22%3A%221000-2000%22%7D&sessionName=asdf1234asdf1234&operation=create&elementType=lead'
 
 
+  it 'should build array', ->
+    vars =
+      json_property:
+        '0.foo.bar': 'baz'
+        '1.foo.bip': 'bap'
+        '1.foo.bar': 'bip'
+    assert.equal integration.request(vars).body, '[{"foo":{"bar":"baz"}},{"foo":{"bip":"bap","bar":"bip"}}]'
+
+
+  it 'should build object even though a json property has a leading digit', ->
+    vars =
+      json_property:
+        '0.foo.bar': 'baz'
+        'bip': 'bap'
+    assert.equal integration.request(vars).body, '{"0":{"foo":{"bar":"baz"}},"bip":"bap"}'
+
+
+
 describe 'JSON validation', ->
 
   it 'should require valid URL', ->

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -13,7 +13,21 @@ headers = require('./headers')
 #
 
 request = (vars) ->
-  body = JSON.stringify(normalize(vars.json_property, vars.send_ascii?.valueOf() ? false))
+
+  json = normalize(vars.json_property, vars.send_ascii?.valueOf() ? false)
+
+  # test whether the mappings indicate that a root array is being requested
+  keys = Object.keys(json)
+  rootArray = _.every keys, (key) ->
+    key.match(/^\d+$/)
+
+  if rootArray
+    array = []
+    for key, value of json
+      array[key] = value
+    json = array
+
+  body = JSON.stringify(json)
 
   defaultHeaders =
     'Content-Type': 'application/json; charset=utf-8'


### PR DESCRIPTION
Fixes a problem reported by Paul in [slack](https://activeprospect.slack.com/archives/support/p1472145272000318).