### PR TITLE
fix for form parameter names with [brackets]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.4] - 2016-08-29
+### Fixed
+- `form_field.*` field names with brackets are correctly preserved (issue #8)
+
 ## [2.8.3] - 2016-08-25
 ### Fixed
 - When all `json_property` values have a leading digit, assume the user wants a root array.

--- a/spec/form-spec.coffee
+++ b/spec/form-spec.coffee
@@ -66,6 +66,14 @@ describe 'Outbound Form POST request', ->
     assert.equal integration.request(vars).body, 'foo.bar.baz=bip'
 
 
+  it 'should support simple bracket notation', ->
+    vars =
+      form_field:
+        'profile[what_is_your_interest]': 'whatever'
+
+    assert.equal integration.request(vars).body, 'profile%5Bwhat_is_your_interest%5D=whatever'
+
+
   it 'should support dot-notation arrays', ->
     vars =
       form_field:

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -142,6 +142,14 @@ describe 'Outbound JSON request', ->
     assert.equal integration.request(vars).body, '[{"foo":{"bar":"baz"}},{"foo":{"bip":"bap","bar":"bip"}}]'
 
 
+  it 'should support brackets in key names', ->
+    vars =
+      json_property:
+        'foo.bar[what_is_your_interest]': 'astrophysics'
+
+    assert.equal integration.request(vars).body, '{"foo":{"bar[what_is_your_interest]":"astrophysics"}}'
+
+
   it 'should build array with missing index', ->
     vars =
       json_property:

--- a/src/normalize.coffee
+++ b/src/normalize.coffee
@@ -12,7 +12,7 @@ module.exports = normalize = (obj, toAscii = false) ->
     continue if typeof value == 'undefined'
     
     # use valueOf to ensure the normal version is sent for all richly typed values
-    value =
+    content[key] =
       if value?.valid == false
         # invalid richly typed values should be set to the raw value
         if toAscii then unidecode(value.raw) else value.raw
@@ -22,6 +22,4 @@ module.exports = normalize = (obj, toAscii = false) ->
         else
           null
 
-    _.set(content, key, value)
-
-  content
+  flat.unflatten content


### PR DESCRIPTION
Fix for #8. 

I didn't find a way to keep `_.set()` from treating brackets in the `key` as part of the path, and turning them into sub-objects.