### PR TITLE
Plain text capture

### DIFF
--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -343,7 +343,6 @@ describe 'Response', ->
       assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), expected
 
 
-
     it 'should not choke on bad capture group', ->
       vars =
         outcome_on_match: 'failure'

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -224,7 +224,7 @@ describe 'Response', ->
       vars = outcome_search_term: 'bar'
       res = xml(foo: 'bar')
       res.headers['Content-Type'] = 'application/json'
-      assert.deepEqual response(vars, {}, res), outcome: 'success'
+      assert.deepEqual response(vars, {}, res).outcome, 'success'
 
 
     it 'should revert to regex on non-JSON body', ->
@@ -240,70 +240,80 @@ describe 'Response', ->
 
   describe 'with plain text body', ->
 
+    it 'should include response body in event object', ->
+      assert.deepEqual response({}, {}, text('foo')), outcome: 'success', body: 'foo'
+
+
+    it 'should truncate response bodies longer than 128 characters', ->
+      long_string = ""
+      long_string += Math.random().toString(36).substr(2) while long_string.length < 256
+      assert.deepEqual response({}, {}, text(long_string)), outcome: 'success', body: long_string.substring(0,128)
+
+
     it 'should default to success without search term', ->
-      assert.deepEqual response({}, {}, text('foo')), outcome: 'success'
+      assert.deepEqual response({}, {}, text('foo')).outcome, 'success'
 
 
     it 'should default to failure per outcome on match', ->
-      assert.deepEqual response(outcome_on_match: 'failure', {}, text('foo')), outcome: 'failure'
+      assert.deepEqual response(outcome_on_match: 'failure', {}, text('foo')).outcome, 'failure'
 
 
     it 'should find search term with exact match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('foo')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, text('foo')).outcome, 'success'
 
 
     it 'should not find search term', ->
-      assert.deepEqual response(outcome_search_term: 'bip', {}, text('foo')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'bip', {}, text('foo')).outcome, 'failure'
 
 
     it 'should return failure on match per outcome on match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, text('foo')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, text('foo')).outcome, 'failure'
 
 
     it 'should find search term with partial match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('barfoobaz')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, text('barfoobaz')).outcome, 'success'
 
 
     it 'should find search term with regex', ->
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, text('barfoobaz')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, text('barfoobaz')).outcome, 'success'
 
 
     it 'should find search term with regex including slashes', ->
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, text('barfoobaz')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, text('barfoobaz')).outcome, 'success'
 
 
     it 'should not error on invalid regex search term', ->
-      assert.deepEqual response(outcome_search_term: '/[/', {}, text('foo')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: '/[/', {}, text('foo')).outcome, 'failure'
 
 
     it 'should find search term with case insensitve match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('FOO')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, text('FOO')).outcome, 'success'
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('bar')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, text('bar')).outcome, 'failure'
 
 
     it 'should parse reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure', reason: 'the reason text!'
 
 
     it 'should parse reason with slashes', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '/[a-z]+:(.*)/'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure', reason: 'the reason text!'
 
 
     it 'should discard empty reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:')), outcome: 'failure'
-      assert.deepEqual response(vars, {}, text('bad:     ')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:')), body: 'bad:', outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:     ')), body: 'bad:     ', outcome: 'failure'
 
 
     it 'should return default reason', ->
@@ -314,7 +324,7 @@ describe 'Response', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure'
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -322,14 +332,14 @@ describe 'Response', ->
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
         default_reason: 'just because'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'just because'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure', reason: 'just because'
 
 
     it 'should revert to string search on non-text body', ->
       vars = outcome_search_term: 'bar'
       res = json(foo: 'bar')
       res.headers['Content-Type'] = 'plain/text'
-      assert.deepEqual response(vars, {}, res), outcome: 'success'
+      assert.deepEqual response(vars, {}, res).outcome, 'success'
 
 
 
@@ -500,7 +510,7 @@ describe 'Response', ->
       vars = outcome_search_term: 'bar'
       res = json(foo: 'bar')
       res.headers['Content-Type'] = 'text/html'
-      assert.deepEqual response(vars, {}, res), outcome: 'success'
+      assert.deepEqual response(vars, {}, res).outcome, 'success'
 
 
 
@@ -780,7 +790,7 @@ describe 'Response', ->
           'Content-Type': 'text/plain'
           'Content-Length': 6
         body: 'oh no!'
-      assert.deepEqual response({}, {}, res), outcome: 'success'
+      assert.deepEqual response({}, {}, res).outcome, 'success'
 
     it 'should return success on HTTP 200 if no outcome and search term are specified', ->
       res =
@@ -789,7 +799,7 @@ describe 'Response', ->
           'Content-Type': 'text/html'
           'Content-Length': 0
         body: ''
-      assert.deepEqual response({outcome_search_term: null, outcome_on_match: null}, {}, res), outcome: 'success'
+      assert.deepEqual response({outcome_search_term: null, outcome_on_match: null}, {}, res).outcome, 'success'
 
 
 

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -343,6 +343,15 @@ describe 'Response', ->
       assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), expected
 
 
+
+    it 'should not choke on bad capture group', ->
+      vars =
+        outcome_on_match: 'failure'
+        capture:
+          bad: '/bad: (.*/x'
+      assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), outcome: 'failure'
+
+
     it 'should revert to string search on non-text body', ->
       vars = outcome_search_term: 'bar'
       res = json(foo: 'bar')

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -241,13 +241,7 @@ describe 'Response', ->
   describe 'with plain text body', ->
 
     it 'should include response body in event object', ->
-      assert.deepEqual response({}, {}, text('foo')), outcome: 'success', body: 'foo'
-
-
-    it 'should truncate response bodies longer than 128 characters', ->
-      long_string = ""
-      long_string += Math.random().toString(36).substr(2) while long_string.length < 256
-      assert.deepEqual response({}, {}, text(long_string)), outcome: 'success', body: long_string.substring(0,128)
+      assert.deepEqual response({}, {}, text('foo')), outcome: 'success'
 
 
     it 'should default to success without search term', ->
@@ -298,22 +292,22 @@ describe 'Response', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure', reason: 'the reason text!'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!'
 
 
     it 'should parse reason with slashes', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '/[a-z]+:(.*)/'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure', reason: 'the reason text!'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!'
 
 
     it 'should discard empty reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:')), body: 'bad:', outcome: 'failure'
-      assert.deepEqual response(vars, {}, text('bad:     ')), body: 'bad:     ', outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:     ')), outcome: 'failure'
 
 
     it 'should return default reason', ->
@@ -324,7 +318,7 @@ describe 'Response', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure'
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -332,7 +326,21 @@ describe 'Response', ->
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
         default_reason: 'just because'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), body: 'bad:the reason text!', outcome: 'failure', reason: 'just because'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'just because'
+
+
+    it 'should use capture groups', ->
+      vars =
+        outcome_on_match: 'failure'
+        capture:
+          bad: '/bad: (.*)$/m'
+          why: '/why: (.*)$/m'
+      expected =
+        outcome: 'failure'
+        bad: 'the reason text!'
+        why: 'just because'
+
+      assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), expected
 
 
     it 'should revert to string search on non-text body', ->
@@ -449,7 +457,7 @@ describe 'Response', ->
         reason: 'just because'
       assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message">just because</div>')), expected
 
-      
+
     it 'should parse reason from attribute', ->
       vars =
         outcome_search_term: 'foo'

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -135,8 +135,7 @@ response = (vars, req, res) ->
       # Response is plain text. Use "capture" variables to capture parts of the text into properties.
       e = {}
       for property, regex of vars.capture ? {}
-        regex = toRegex(regex)
-        value = doc.match(regex)?[1]
+        value = doc.match(toRegex(regex))?[1]
         e[property] = value if value?
       e
 

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -136,8 +136,8 @@ response = (vars, req, res) ->
       e = {}
       for property, regex of vars.capture ? {}
         regex = toRegex(regex)
-        if value = doc.match(regex)?[1]
-          e[property] = value
+        value = doc.match(regex)?[1]
+        e[property] = value if value?
       e
 
   event ?= {}

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -129,7 +129,11 @@ response = (vars, req, res) ->
         trim: true
       try doc.toObject(opts) catch
     else if _.isPlainObject(doc)
+      # This is a JSON object
       doc
+    else if not _.isFunction(doc.html) and typeof doc is 'string'
+      # Response is plain text. Keep up to 128 characters.
+      {"body": doc.substring(0,128)}
 
   event ?= {}
   event.outcome = outcome

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -132,8 +132,13 @@ response = (vars, req, res) ->
       # This is a JSON object
       doc
     else if not _.isFunction(doc.html) and typeof doc is 'string'
-      # Response is plain text. Keep up to 128 characters.
-      {"body": doc.substring(0,128)}
+      # Response is plain text. Use "capture" variables to capture parts of the text into properties.
+      e = {}
+      for property, regex of vars.capture ? {}
+        regex = toRegex(regex)
+        if value = doc.match(regex)?[1]
+          e[property] = value
+      e
 
   event ?= {}
   event.outcome = outcome

--- a/src/variables.coffee
+++ b/src/variables.coffee
@@ -6,4 +6,5 @@ module.exports = [
   { name: 'default_reason', description: 'Failure reason when no reason can be found per the optional Reason Path setting', type: 'string', required: false }
   { name: 'header.*', description: 'HTTP header to send in the request', type: 'wildcard', required: false }
   { name: 'send_ascii', description: 'Set to true to ensure lead data is sent as ASCII for legacy recipients (default: false)', type: 'boolean', required: false }
+  { name: 'capture.*', description: 'A named regular expression with a single capture group, used to capture values from plain text responses into the named property', type: 'wildcard' }
 ]


### PR DESCRIPTION
This PR was based off of #37.

The change adds a feature that captures part of a text/plain response body using a regular expression. For example...

Response body:
```
foo: bar
baz: bip
```

Mapping: 
```json
{ 
  "property": "capture.baz",
  "value": "/baz: (.*)$/m"
}
```

And the integration will append:
```json
{
  "outcome": "success",
  "baz": "bip"
}
```
