### PR TITLE
fix to extract failure reason text from XML CDATA

### DIFF
--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -686,6 +686,29 @@ describe 'Response', ->
       assert.deepEqual response(vars, {}, xml(baz: { bip: 'the reason text!'})), expected
 
 
+    it 'should parse reason from CDATA', ->
+      vars =
+        outcome_search_term: 'success'
+        reason_path: '/baz/bip/text()'
+
+      body = '<baz><bip><![CDATA[the reason character data!]]></bip></baz>'
+
+      res =
+        status: 200
+        headers:
+          'Content-Type': 'text/xml'
+          'Content-Length': body.length
+        body: body
+
+      expected =
+        outcome: 'failure'
+        reason: 'the reason text!'
+
+      event = response(vars, {}, res)
+      assert.equal event.outcome, 'failure'
+      assert.equal event.reason, 'the reason character data!'
+
+
     it 'should discard empty reason', ->
       vars =
         outcome_search_term: 'foo'

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -108,6 +108,7 @@ response = (vars, req, res) ->
 
   # trim and comma delimit reasons
   reason = _(ensureArray(reasons))
+    .map extractCData
     .map _.trim
     .compact()
     .sort()
@@ -182,3 +183,9 @@ toDoc = (body, contentType) ->
 errorStatus = (statusCode) ->
   error = statusCode % 500
   error >= 0 and error < 100
+
+
+# if the given value is CDATA, extract that character data from the <![CDATA[...]]> wrapper
+extractCData = (value) ->
+  return unless value
+  value.nodeValue ? value.toString()


### PR DESCRIPTION
Saw this yesterday in [an Annie's lead](https://next.leadconduit.com/events/57dfdd1cd4630904e874347f?event_id=57dfdd1cd4630904e8743482&flow_id=57d70e7fc393850bfe459c1e&type=source&start=2016-09-19&end=2016-09-19). The Xpath mapping is right, but it's capturing `<![CDATA[Unable to Add Recipient. Recipient Already Exists.]]>`. I can't think of a case where anyone _wants_ that `<![CDATA[…]]>` junk in their failure reasons.