### PR TITLE
Support numeric JSON properties using non-standard dot-notation syntax

### DIFF
--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -83,6 +83,15 @@ describe 'Outbound JSON request', ->
     assert.equal integration.request(vars).body, '{"foo":{"bar":{"baz":["bip","bap"]}}}'
 
 
+  it 'should support numeric object properties', ->
+    vars =
+      json_property:
+        'foo.bar.baz{0}': 'bip'
+        'foo.bar.baz{1}': 'bap'
+
+    assert.equal integration.request(vars).body, '{"foo":{"bar":{"baz":{"0":"bip","1":"bap"}}}}'
+
+
   it 'should normalize rich types', ->
     vars =
       json_property:

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -92,6 +92,24 @@ describe 'Outbound JSON request', ->
     assert.equal integration.request(vars).body, '{"foo":{"bar":{"baz":{"0":"bip","1":"bap"}}}}'
 
 
+  it 'should support intermediate numeric object properties', ->
+    vars =
+      json_property:
+        'foo.bar{0}.bip': true
+        'foo.bar{1}.bip': false
+
+    assert.equal integration.request(vars).body, '{"foo":{"bar":{"0":{"bip":true},"1":{"bip":false}}}}'
+
+
+  it 'should support multiple intermediate numeric object properties', ->
+    vars =
+      json_property:
+        'foo{0}.bar{0}.bip': true
+        'foo{1}.bar{1}.bip': false
+
+    assert.equal integration.request(vars).body, '{"foo":{"0":{"bar":{"0":{"bip":true}}},"1":{"bar":{"1":{"bip":false}}}}}'
+
+
   it 'should normalize rich types', ->
     vars =
       json_property:

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -157,6 +157,24 @@ describe 'Outbound XML request', ->
       """
 
 
+  it 'should not support numeric elements', ->
+    # xml doesn't support numeric element names
+    vars =
+      xml_path:
+        'foo.bar.baz{0}': 'bip'
+        'foo.bar.baz{1}': 'bap'
+
+    assert.equal integration.request(vars).body,
+      """
+      <?xml version="1.0"?>
+      <foo>
+        <bar>
+          <baz>bip</baz>
+          <baz>bap</baz>
+        </bar>
+      </foo>
+      """
+
   it 'should normalize rich types', ->
     vars =
       xml_path:

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -15,7 +15,7 @@ compact = require('./compact')
 
 request = (vars) ->
 
-  json = normalize(vars.json_property, vars.send_ascii?.valueOf() ? false)
+  json = normalize(vars.json_property, vars.send_ascii?.valueOf() ? false) ? {}
 
   # test whether the mappings indicate that a root array is being requested
   keys = Object.keys(json)

--- a/src/normalize.coffee
+++ b/src/normalize.coffee
@@ -2,24 +2,36 @@ _ = require('lodash')
 flat = require('flat')
 unidecode = require('unidecode')
 
+numericPropertyRegexp = /(.*)(\{\d+\})$/
+numericPropertyBracketRegexp = /[{}]/g
 
-module.exports = normalize = (obj, toAscii = false) ->
+# use valueOf to ensure the normal version is sent for all richly typed values
+valueOf = (value, toAscii) ->
+  if value?.valid == false
+    # invalid richly typed values should be set to the raw value
+    if toAscii then unidecode(value.raw) else value.raw
+  else
+    if value?.valueOf()?
+      if toAscii then unidecode(value.valueOf()) else value.valueOf()
+    else
+      null
+
+
+module.exports = (obj, toAscii = false) ->
   content = {}
   return content unless obj?
 
   for key, value of flat.flatten(obj)
     # fields with undefined as the value are not included
     continue if typeof value == 'undefined'
-    
-    # use valueOf to ensure the normal version is sent for all richly typed values
-    content[key] =
-      if value?.valid == false
-        # invalid richly typed values should be set to the raw value
-        if toAscii then unidecode(value.raw) else value.raw
-      else
-        if value?.valueOf()?
-          if toAscii then unidecode(value.valueOf()) else value.valueOf()
-        else
-          null
+
+    if match = key.match(numericPropertyRegexp)
+      # numeric object property notation
+      key = match[1]
+      property = match[2].replace(numericPropertyBracketRegexp, '')
+      content[key] ?= {}
+      content[key][property] = valueOf(value, toAscii)
+    else
+      content[key] = valueOf(value, toAscii)
 
   flat.unflatten content

--- a/src/normalize.coffee
+++ b/src/normalize.coffee
@@ -2,11 +2,12 @@ _ = require('lodash')
 flat = require('flat')
 unidecode = require('unidecode')
 
-numericPropertyRegexp = /(.*)(\{\d+\})$/
+numericPropertyRegexp = /(.*)(\{\d+\})/
 numericPropertyBracketRegexp = /[{}]/g
 
 # use valueOf to ensure the normal version is sent for all richly typed values
 valueOf = (value, toAscii) ->
+  return value unless value?
   if value?.valid == false
     # invalid richly typed values should be set to the raw value
     if toAscii then unidecode(value.raw) else value.raw
@@ -17,21 +18,25 @@ valueOf = (value, toAscii) ->
       null
 
 
-module.exports = (obj, toAscii = false) ->
-  content = {}
-  return content unless obj?
+module.exports = normalize = (obj, toAscii = false) ->
+  return obj unless obj?
 
-  for key, value of flat.flatten(obj)
-    # fields with undefined as the value are not included
-    continue if typeof value == 'undefined'
-
-    if match = key.match(numericPropertyRegexp)
-      # numeric object property notation
-      key = match[1]
-      property = match[2].replace(numericPropertyBracketRegexp, '')
-      content[key] ?= {}
-      content[key][property] = valueOf(value, toAscii)
-    else
-      content[key] = valueOf(value, toAscii)
-
-  flat.unflatten content
+  if _.isArray(obj)
+    obj.map (val) ->
+      normalize(val, toAscii)
+  else if _.isPlainObject(obj)
+    rtn = {}
+    for key, value of flat.unflatten(obj)
+      value = normalize(value, toAscii)
+      continue if value == undefined
+      if match = key.match(numericPropertyRegexp)
+        # numeric object property notation
+        key = match[1]
+        property = match[2].replace(numericPropertyBracketRegexp, '')
+        rtn[key] ?= {}
+        rtn[key][property] = value
+      else
+        rtn[key] = value
+    rtn
+  else
+    valueOf(obj, toAscii)

--- a/src/xml-doc.coffee
+++ b/src/xml-doc.coffee
@@ -10,7 +10,7 @@ compact = require('./compact')
 #
 module.exports = (obj, toAscii = false) ->
 
-  xmlPaths = flat.flatten(normalize(obj, toAscii))
+  xmlPaths = flat.flatten(normalize(obj, toAscii) ? {})
 
   xmlPaths =
     _(xmlPaths)


### PR DESCRIPTION
Numeric property names are supported in JSON, but a mapping property that ends in `.` followed by a digit is assumed to be an array. This PR adds a new syntax for forcing numeric properties. Setting the mapping property to `foo.bar{999}` and value to `"abc"` will cause the following JSON to be rendered:

```json
{ 
  "foo": {
    "bar": {
      "999": "abc"
    }
  }
}
```

See: https://activeprospect.zendesk.com/agent/tickets/11380