### PR TITLE
Numeric JSON property handling is now done by the LeadConduit mappings

### DIFF
--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -83,33 +83,6 @@ describe 'Outbound JSON request', ->
     assert.equal integration.request(vars).body, '{"foo":{"bar":{"baz":["bip","bap"]}}}'
 
 
-  it 'should support numeric object properties', ->
-    vars =
-      json_property:
-        'foo.bar.baz{0}': 'bip'
-        'foo.bar.baz{1}': 'bap'
-
-    assert.equal integration.request(vars).body, '{"foo":{"bar":{"baz":{"0":"bip","1":"bap"}}}}'
-
-
-  it 'should support intermediate numeric object properties', ->
-    vars =
-      json_property:
-        'foo.bar{0}.bip': true
-        'foo.bar{1}.bip': false
-
-    assert.equal integration.request(vars).body, '{"foo":{"bar":{"0":{"bip":true},"1":{"bip":false}}}}'
-
-
-  it 'should support multiple intermediate numeric object properties', ->
-    vars =
-      json_property:
-        'foo{0}.bar{0}.bip': true
-        'foo{1}.bar{1}.bip': false
-
-    assert.equal integration.request(vars).body, '{"foo":{"0":{"bar":{"0":{"bip":true}}},"1":{"bar":{"1":{"bip":false}}}}}'
-
-
   it 'should normalize rich types', ->
     vars =
       json_property:

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -157,24 +157,6 @@ describe 'Outbound XML request', ->
       """
 
 
-  it 'should not support numeric elements', ->
-    # xml doesn't support numeric element names
-    vars =
-      xml_path:
-        'foo.bar.baz{0}': 'bip'
-        'foo.bar.baz{1}': 'bap'
-
-    assert.equal integration.request(vars).body,
-      """
-      <?xml version="1.0"?>
-      <foo>
-        <bar>
-          <baz>bip</baz>
-          <baz>bap</baz>
-        </bar>
-      </foo>
-      """
-
   it 'should normalize rich types', ->
     vars =
       xml_path:

--- a/src/normalize.coffee
+++ b/src/normalize.coffee
@@ -2,9 +2,6 @@ _ = require('lodash')
 flat = require('flat')
 unidecode = require('unidecode')
 
-numericPropertyRegexp = /(.*)(\{\d+\})/
-numericPropertyBracketRegexp = /[{}]/g
-
 # use valueOf to ensure the normal version is sent for all richly typed values
 valueOf = (value, toAscii) ->
   return value unless value?
@@ -28,15 +25,7 @@ module.exports = normalize = (obj, toAscii = false) ->
     rtn = {}
     for key, value of flat.unflatten(obj)
       value = normalize(value, toAscii)
-      continue if value == undefined
-      if match = key.match(numericPropertyRegexp)
-        # numeric object property notation
-        key = match[1]
-        property = match[2].replace(numericPropertyBracketRegexp, '')
-        rtn[key] ?= {}
-        rtn[key][property] = value
-      else
-        rtn[key] = value
+      rtn[key] = value
     rtn
   else
     valueOf(obj, toAscii)


### PR DESCRIPTION
The trick to integrations supporting numeric properties is that they cannot use `flat.flatten()`. This causes an irretrievable loss of the differentiation between `{ "foo": [ "bar" ] }` and `{ "foo": { "0": "bar" } }`. This integration no longer calls `flat.flatten()`.

All tests for numeric properties are now in the leadconduit-dotpath module.