### PR TITLE
Extract cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "soap": "~0.17.0",
     "unidecode": "^0.1.8",
     "xml2js": "^0.4.16",
-    "xmlbuilder": "^7.0.0"
+    "xmlbuilder": "^7.0.0",
+    "set-cookie-parser": "^2.0.0"
   },
   "devDependencies": {
     "chai": ">= 1.9.0",

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -251,7 +251,7 @@ describe 'Response', ->
         message: "PhoneNumber is a required field."
         reason: "PhoneNumber is a required field."
       assert.deepEqual response(vars, {}, res), expected
- 
+
 
   describe 'with plain text body', ->
 
@@ -863,6 +863,125 @@ describe 'Response', ->
           'Content-Length': 0
         body: ''
       assert.deepEqual response({outcome_search_term: null, outcome_on_match: null}, {}, res).outcome, 'success'
+
+
+  describe 'cookie handling', ->
+
+    it 'should not capture response cookies if not requested by the user', ->
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': 'session_id=12345; path=/; domain=.fizzbuzz.com"
+      assert.deepEqual response(vars, {}, res), outcome: "success"
+
+    it 'should capture response cookies into named property if specified in vars, with proper types for each cookie attribute', ->
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': 'session_id=12345; path=/; domain=.fizzbuzz.com; expires=Sat, 01-Jan-2022 16:39:03 GMT; Max-Age=155520000; secure; httpOnly'
+      vars = 
+        collect_cookies: "cookie_monster"
+      expected =
+        "session_id":
+          name: "session_id"
+          value: "12345"
+          path: "/"
+          domain: ".fizzbuzz.com" //string
+          expires: Date("Sat, 01-Jan-2022 16:39:03 GMT") //Date object
+          maxAge: 155520000, //number
+          secure: true, //boolean
+          httpOnly: true
+      assert.deepEqual response(vars, {}, res).cookie_monster, expected 
+
+    it 'should handle multiple, unique cookies (cookies with distinct cookie-name)', ->
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': 'foo=fizz'
+          'Set-Cookie': 'bar=buzz'
+      vars = 
+        collect_cookies: "cookie_monster"
+      expected =
+        "foo":
+          "name": "foo"
+          "value": "fizz"
+        "bar":
+          "name": "bar"
+          "value": "buzz"
+      assert.deepEqual response(vars, {}, res).cookie_monster, expected
+
+    // RFC 6265 (4.1.1) says that multiple Set-Cookie headers with the same
+    // cookie-name is a no-no. RFC 6265 (5.3) also states that in such cases,
+    // the cookie user agents are to pick the latest Set-Cookie if more than
+    // one cookie has the same (cookie-name, domain-value, path-value) tuple.
+    // Otherwise, the user agent treats the two cookies (with same cookie-name)
+    // as different cookies.
+
+    it 'should handle multiple cookies with duplicate cookie-name, but different domain-value and/or path-value', ->
+
+    // The top-level cookie object name will then reference an array of cookie
+    // objects, rather than a cookie object directly.
+
+      return False
+
+    it 'should handle multiple cookies with duplicate cookie-name, domain-value, and path-value', ->
+
+    // The last Set-Cookie in the headers takes precedent.
+
+      return False
+
+    // RFC 6265 (4.1.1) specifies that arbitrary data in cookie-values SHOULD
+    // be encoded, but makes no requirement on the type of encoding (it only
+    // mentions Base64 as an example of an encoding). The grammar defined in
+    // section 4.1.1 for "cookie-octet" lends itself to most users utilizing
+    // the encodeURIComponent() function for the purpose of conforming to that
+    // grammar. The MDN also recommends encodeURIComponent:
+    //
+    // https://developer.mozilla.org/en-US/docs/Web/API/document/cookie
+    //
+    // and most projects involving cookie handling also conform to this
+    // convention (as does the underling set-cookie-parser library in use
+    // here).
+
+    it 'should URIdecode cookie-values by default', ->
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': 'user_id=cookie_monster%40sesamestreet.com'
+      vars = 
+        collect_cookies: "cookie_monster"
+      expected =
+        "user_id":
+          "name": "user_id"
+          "value": "cookie_monster@sesamestreet.com"
+      assert.deepEqual response(vars, {}, res).cookie_monster, expected
+
+    it 'should fall back to non-decoded URI string if URIdecode fails (malformed URI)', ->
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': 'foo=bar_%F'
+      vars = 
+        collect_cookies: "cookie_monster"
+      expected =
+        "foo":
+          "name": "foo"
+          "value": "bar_%F"
+      assert.deepEqual response(vars, {}, res).cookie_monster, expected
+
+    it 'should leave cookie-value undecoded if requested by user', ->
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': 'user_id=foo%40bar.com'
+      vars = 
+        collect_cookies: "cookie_monster"
+        collect_cookies_decode: false
+      expected =
+        "user_id":
+          "name": "user_id"
+          "value": "foo%40bar.com"
+      assert.deepEqual response(vars, {}, res).cookie_monster, expected
 
 
 

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -872,7 +872,7 @@ describe 'Response', ->
         status: 200
         headers:
           'Set-Cookie': ['session_id=12345; path=/; domain=.fizzbuzz.com']
-      assert.deepEqual response(vars, {}, res), outcome: "success"
+      assert.deepEqual response({}, {}, res), outcome: "success"
 
     it 'should capture response cookies into named property if specified in vars, with proper types for each cookie attribute', ->
       res =
@@ -886,10 +886,10 @@ describe 'Response', ->
           name: "session_id"
           value: "12345"
           path: "/"
-          domain: ".fizzbuzz.com" //string
-          expires: Date("Sat, 01-Jan-2022 16:39:03 GMT") //Date object
-          maxAge: 155520000, //number
-          secure: true, //boolean
+          domain: ".fizzbuzz.com" #string
+          expires: Date("Sat, 01-Jan-2022 16:39:03 GMT") #Date object
+          maxAge: 155520000, #number
+          secure: true, #boolean
           httpOnly: true
       assert.deepEqual response(vars, {}, res).cookie_monster, expected 
 
@@ -909,16 +909,16 @@ describe 'Response', ->
           "value": "buzz"
       assert.deepEqual response(vars, {}, res).cookie_monster, expected
 
-    // RFC 6265 (4.1.1) says that multiple Set-Cookie headers with the same
-    // cookie-name is a no-no. RFC 6265 (5.3) also states that in such cases,
-    // the cookie user agents are to pick the latest Set-Cookie if more than
-    // one cookie has the same (cookie-name, domain-value, path-value) tuple.
-    // Otherwise, the user agent treats the two cookies (with same cookie-name)
-    // as different cookies.
+    # RFC 6265 (4.1.1) says that multiple Set-Cookie headers with the same
+    # cookie-name is a no-no. RFC 6265 (5.3) also states that in such cases,
+    # the cookie user agents are to pick the latest Set-Cookie if more than
+    # one cookie has the same (cookie-name, domain-value, path-value) tuple.
+    # Otherwise, the user agent treats the two cookies (with same cookie-name)
+    # as different cookies.
 
     it 'should handle multiple cookies with duplicate cookie-name, but different domain-value and/or path-value', ->
-      // The top-level cookie object name will then reference an array of cookie
-      // objects, rather than a cookie object directly.
+      # The top-level cookie object name will then reference an array of cookie
+      # objects, rather than a cookie object directly.
       res =
         status: 200
         headers:
@@ -930,13 +930,13 @@ describe 'Response', ->
         collect_cookies: "cookie_monster"
       expected =
         "foo": [
-          {"name":"fizz", path="/", domain=".fizzbuzz.com"},
-          {"name":"buzz", path="/somepath", domain=".fizzbuzz.com"}
+          {"name":"fizz", "path":"/", "domain":".fizzbuzz.com"},
+          {"name":"buzz", "path":"/somepath", "domain":".fizzbuzz.com"}
         ]
       assert.deepEqual response(vars, {}, res).cookie_monster, expected
 
     it 'should handle multiple cookies with duplicate cookie-name, domain-value, and path-value', ->
-      // The last Set-Cookie in the headers takes precedent.
+      # The last Set-Cookie in the headers takes precedent.
       res =
         status: 200
         headers:
@@ -954,18 +954,18 @@ describe 'Response', ->
           domain: ".fizzbuzz.com"
       assert.deepEqual response(vars, {}, res).cookie_monster, expected 
 
-    // RFC 6265 (4.1.1) specifies that arbitrary data in cookie-values SHOULD
-    // be encoded, but makes no requirement on the type of encoding (it only
-    // mentions Base64 as an example of an encoding). The grammar defined in
-    // section 4.1.1 for "cookie-octet" lends itself to most users utilizing
-    // the encodeURIComponent() function for the purpose of conforming to that
-    // grammar. The MDN also recommends encodeURIComponent:
-    //
-    // https://developer.mozilla.org/en-US/docs/Web/API/document/cookie
-    //
-    // and most projects involving cookie handling also conform to this
-    // convention (as does the underling set-cookie-parser library in use
-    // here).
+    # RFC 6265 (4.1.1) specifies that arbitrary data in cookie-values SHOULD
+    # be encoded, but makes no requirement on the type of encoding (it only
+    # mentions Base64 as an example of an encoding). The grammar defined in
+    # section 4.1.1 for "cookie-octet" lends itself to most users utilizing
+    # the encodeURIComponent() function for the purpose of conforming to that
+    # grammar. The MDN also recommends encodeURIComponent:
+    #
+    # https://developer.mozilla.org/en-US/docs/Web/API/document/cookie
+    #
+    # and most projects involving cookie handling also conform to this
+    # convention (as does the underling set-cookie-parser library in use
+    # here).
 
     it 'should URIdecode cookie-values by default', ->
       res =

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -871,14 +871,14 @@ describe 'Response', ->
       res =
         status: 200
         headers:
-          'Set-Cookie': 'session_id=12345; path=/; domain=.fizzbuzz.com"
+          'Set-Cookie': ['session_id=12345; path=/; domain=.fizzbuzz.com']
       assert.deepEqual response(vars, {}, res), outcome: "success"
 
     it 'should capture response cookies into named property if specified in vars, with proper types for each cookie attribute', ->
       res =
         status: 200
         headers:
-          'Set-Cookie': 'session_id=12345; path=/; domain=.fizzbuzz.com; expires=Sat, 01-Jan-2022 16:39:03 GMT; Max-Age=155520000; secure; httpOnly'
+          'Set-Cookie': ['session_id=12345; path=/; domain=.fizzbuzz.com; expires=Sat, 01-Jan-2022 16:39:03 GMT; Max-Age=155520000; secure; httpOnly']
       vars = 
         collect_cookies: "cookie_monster"
       expected =
@@ -897,8 +897,7 @@ describe 'Response', ->
       res =
         status: 200
         headers:
-          'Set-Cookie': 'foo=fizz'
-          'Set-Cookie': 'bar=buzz'
+          'Set-Cookie': ['foo=fizz','bar=buzz']
       vars = 
         collect_cookies: "cookie_monster"
       expected =
@@ -918,17 +917,42 @@ describe 'Response', ->
     // as different cookies.
 
     it 'should handle multiple cookies with duplicate cookie-name, but different domain-value and/or path-value', ->
-
-    // The top-level cookie object name will then reference an array of cookie
-    // objects, rather than a cookie object directly.
-
-      return False
+      // The top-level cookie object name will then reference an array of cookie
+      // objects, rather than a cookie object directly.
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': [
+            'foo=fizz; path=/; domain=.fizzbuzz.com',
+            'foo=buzz; path=/somepath; domain=.fizzbuzz.com'
+          ]
+      vars =
+        collect_cookies: "cookie_monster"
+      expected =
+        "foo": [
+          {"name":"fizz", path="/", domain=".fizzbuzz.com"},
+          {"name":"buzz", path="/somepath", domain=".fizzbuzz.com"}
+        ]
+      assert.deepEqual response(vars, {}, res).cookie_monster, expected
 
     it 'should handle multiple cookies with duplicate cookie-name, domain-value, and path-value', ->
-
-    // The last Set-Cookie in the headers takes precedent.
-
-      return False
+      // The last Set-Cookie in the headers takes precedent.
+      res =
+        status: 200
+        headers:
+          'Set-Cookie': [
+            'session_id=12345; path=/; domain=.fizzbuzz.com',
+            'session_id=54321; path=/; domain=.fizzbuzz.com'
+          ]
+      vars = 
+        collect_cookies: "cookie_monster"
+      expected =
+        "session_id":
+          name: "session_id"
+          value: "54321"
+          path: "/"
+          domain: ".fizzbuzz.com"
+      assert.deepEqual response(vars, {}, res).cookie_monster, expected 
 
     // RFC 6265 (4.1.1) specifies that arbitrary data in cookie-values SHOULD
     // be encoded, but makes no requirement on the type of encoding (it only
@@ -947,7 +971,7 @@ describe 'Response', ->
       res =
         status: 200
         headers:
-          'Set-Cookie': 'user_id=cookie_monster%40sesamestreet.com'
+          'Set-Cookie': ['user_id=cookie_monster%40sesamestreet.com']
       vars = 
         collect_cookies: "cookie_monster"
       expected =
@@ -960,7 +984,7 @@ describe 'Response', ->
       res =
         status: 200
         headers:
-          'Set-Cookie': 'foo=bar_%F'
+          'Set-Cookie': ['foo=bar_%F']
       vars = 
         collect_cookies: "cookie_monster"
       expected =
@@ -973,7 +997,7 @@ describe 'Response', ->
       res =
         status: 200
         headers:
-          'Set-Cookie': 'user_id=foo%40bar.com'
+          'Set-Cookie': ['user_id=foo%40bar.com']
       vars = 
         collect_cookies: "cookie_monster"
         collect_cookies_decode: false

--- a/src/variables.coffee
+++ b/src/variables.coffee
@@ -8,4 +8,5 @@ module.exports = [
   { name: 'send_ascii', description: 'Set to true to ensure lead data is sent as ASCII for legacy recipients (default: false)', type: 'boolean', required: false }
   { name: 'capture.*', description: 'A named regular expression with a single capture group, used to capture values from plain text responses into the named property', type: 'wildcard' }
   { name: 'response_content_type_override', description: "Override response's Content-Type header with custom value.", type: 'string', required: false }
+  { name: 'collect_cookies', description: "Gather cookies from response into named property.", type: 'string', required: false }
 ]


### PR DESCRIPTION
Howdy folks,

I'm attempting to integrate with a CRM (amoCRM) that expects session tokens to be handled via Cookie headers. The current `header.*` request variable functionality would work for making the Cookie headers on requests to the CRM. However, in this case, the initial setting of the session token is also only available in the Set-Cookie headers of the login response. So far as I know, there is no existing functionality for interrogating response headers (and I can't think of a general way to implement such a feature that would also be useful for further actions in flows, since HTTP headers are largely arbitrary so far as I know).

That being said, Cookie headers in particular are in common use and have specs that try to nail down their behaviour (RFC 6265). I'd like to be able to collect cookies into a named property in the event object if requested, and use their values in subsequent calls. Something like

"header.Cookie": "session_id={{some_previous_destination.some_cookie_holder_property.some_cookie_name.value_raw}}".

This should permit me to integrate with amoCRM.

====================================

I've taken an initial stab at this problem in this pull request. I didn't intend to make a full cookie user agent/cookie jar handler (a bona fide cookie jar would really be more of a flow-level concept). Rather, I just wanted to conveniently expose Set-Cookie header data from a response into an object for later use in the flow. Still, I've included handling for various behaviours that run against RFC 6265 and other edge cases (malformed encodings).

The spec and code assume that `res.headers['Set-Cookie']` is an array of cookie strings. Strictly speaking I don't have visibility into the caller of response() (that is presumably building `res`), but the "Technical Details" of destination requests/responses for any given run through a flow show the Set-Cookie header as such an array. I utilize the set-cookie-parser module to parse each cookie (it's a small one-file module with no dependencies). I then process each cookie to handle RFC-breaking behaviour. And finally I format the cookie into the desired object format in the event.

Let me know what y'all think.