### PR TITLE
fix to parse reason text from JSON array response (fixes #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.14.3] - 2017-06-06
+### Fixed
+- fix to parse reason text from JSON array response
+
+## [2.14.2] - 2017-05-11
+### Fixed
+- compact arrays for SOAP transactions
+
 ## [2.14.1] - 2017-03-06
 ### Fixed
 - fix to cookie header search to ignore case

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -190,6 +190,27 @@ describe 'Response', ->
       assert.deepEqual response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
 
 
+    it 'should parse single reason from array', ->
+      vars =
+        outcome_search_term: 'foo'
+        reason_path: 'baz.bip.1'
+      expected =
+        outcome: 'failure'
+        reason: 'another reason'
+        baz: { bip: ['the reason text!', 'another reason'] }
+      assert.deepEqual response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
+
+
+    it 'should parse reason from array response', ->
+      vars =
+        outcome_search_term: 'foo'
+        reason_path: '0.bip'
+      expected =
+        outcome: 'failure'
+        reason: 'the reason text!'
+      assert.deepEqual response(vars, {}, json( [ {bip: 'the reason text!'} ] )), expected
+
+
     it 'should return default reason', ->
       expected =
         outcome: 'success'

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -102,7 +102,7 @@ response = (vars, req, res) ->
       else
         []
 
-    else if _.isPlainObject(doc)
+    else if _.isPlainObject(doc) or _.isArray(doc)
       # this is a JS object (JSON)
       _.get(doc, reasonSelector)
 


### PR DESCRIPTION
One test (with basic auth) fails in Travis for Node 8.0.0, because of [this bug in Nock](https://github.com/node-nock/nock/issues/928). I'll keep an eye on that and revisit this when it's fixed.