### PR TITLE
Handle wildcard response paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.17.10] - 2018-08-28
+### Added
+- Support wildcards in reason parsing
+
 ## [2.16.1] - 2018-08-16
 ### Fixed
 - update soap package to remove security vulns

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prepublish": "cake build"
   },
   "dependencies": {
+    "dot-wild": "^3.0.1",
     "flat": "^1.6.1",
     "leadconduit-integration": "^0.1.0",
     "lodash": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "type": "git",
     "url": "https://github.com/activeprospect/leadconduit-integration-custom.git"
   },
-  "engines": {
-    "node": ">=0.10"
-  },
   "scripts": {
     "test": "cake test",
     "prepublish": "cake build"

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -240,6 +240,34 @@ describe 'Response', ->
         baz: { bip: 'foo' }
       assert.deepEqual response(vars, {}, json(baz: { bip: 'foo' })), expected
 
+    it 'should successfully parse reason with wildcard in path', ->
+      vars =
+        outcome_search_term: 'bar'
+        reason_path: 'baz.*.details'
+      expected =
+        outcome: 'failure'
+        reason: 'bad data'
+        baz:
+          foo:
+            details: 'bad data'
+
+      assert.deepEqual response(vars, {}, json(baz: { foo: { details: 'bad data' }})), expected
+
+    it 'should successfully parse reason with multiple wildcards in path', ->
+      vars =
+        outcome_search_term: 'bar'
+        reason_path: 'baz.*.details.*.more_details'
+      expected =
+        outcome: 'failure'
+        reason: 'really bad data'
+        baz:
+          foo:
+            details:
+              bip:
+                more_details: 'really bad data'
+         
+      assert.deepEqual response(vars, {}, json(baz: { foo: { details: { bip: { more_details : 'really bad data'}}}})), expected
+
 
     it 'should revert to string search on non-JSON body', ->
       vars = outcome_search_term: 'bar'

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -1,6 +1,7 @@
 _ = require('lodash')
 mimecontent = require('mime-content')
 parseMimeType = require('mimeparse').parseMimeType
+dotWild = require('dot-wild')
 
 helpers = require('./helpers')
 ensureArray = helpers.ensureArray
@@ -104,7 +105,7 @@ response = (vars, req, res) ->
 
     else if _.isPlainObject(doc) or _.isArray(doc)
       # this is a JS object (JSON)
-      _.get(doc, reasonSelector)
+      dotWild.get(doc, reasonSelector)
 
     else if _.isString(doc)
       # this is a plain text. do a regex match and use the first match group
@@ -119,7 +120,6 @@ response = (vars, req, res) ->
     .compact()
     .sort()
     .join(', ')
-
 
   # set the default reason, if necessary
   reason or= vars.default_reason?.trim()


### PR DESCRIPTION
I'm _fairly_ sure this will solve the indeterministic JSON issue mentioned [here](https://activeprospect.slack.com/archives/C034BK84K/p1530040973000097).

closes #64. 