### PR TITLE
Capture price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.18.0] - 2018-10-31
+### Added
+- Capture 'price' response variable
+
 ## [2.17.0] - 2018-08-28
 ### Added
 - Support wildcards in reason parsing

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -301,13 +301,16 @@ describe 'Response', ->
         reason: "PhoneNumber is a required field."
       assert.deepEqual response(vars, {}, res), expected
 
-    it 'should capture price when vars.price is defined', ->
-      vars = cost: 1.5
+    it 'should capture price on success', ->
+      vars = 
+        price_path: 'baz.*.cost'
       expected =
         outcome: 'success'
-        foo: 'bar'
-        price: 1.5
-      assert.deepEqual response(vars, {}, json(foo: 'bar')), expected
+        price: '1.5'
+        baz:
+          foo:
+            cost: 1.5
+      assert.deepEqual response(vars, {}, json(baz: { foo: { cost: 1.5 }})), expected
  
 
   describe 'with plain text body', ->
@@ -430,11 +433,12 @@ describe 'Response', ->
       assert.deepEqual response(vars, {}, res).outcome, 'success'
 
     it 'should capture price when vars.cost is present', ->
-      vars = cost: 1.5
+      vars = 
+        price_path: '/cost=([0-9]\.[0-9])/'
       expected = 
         outcome: 'success'
-        price: 1.5
-      assert.deepEqual response(vars, {}, text('foo')), expected
+        price: '1.5'
+      assert.deepEqual response(vars, {}, text('foo&cost=1.5')), expected
 
   describe 'with html', ->
 
@@ -616,12 +620,13 @@ describe 'Response', ->
 
       assert.deepEqual response(vars, {}, html('<div>result: matched 42 records.</div>')), expected
 
-    it 'should capture price when vars.cost is present', ->
-      vars = cost: 1.5
+    it 'should capture price when price_path is present', ->
+      vars =
+        price_path: 'div.cost'
       expected = 
         outcome: 'success'
-        price: 1.5
-      assert.deepEqual response(vars, {}, html('<div>foo</div>')), expected
+        price: "1.5"
+      assert.deepEqual response(vars, {}, html('<div class="cost">1.5</div>')), expected
 
 
   describe 'with xml body', ->
@@ -881,13 +886,15 @@ describe 'Response', ->
       res.headers['Content-Type'] = 'text/xml'
       assert.deepEqual response(vars, {}, res), outcome: 'success'
 
-    it 'should capture price when vars.cost is present', ->
-      vars = cost: 1.5
+    it 'should capture price', ->
+      vars =
+        price_path: 'bar/cost/text()'
       expected =
+        price: '1.5'
+        bar:
+          cost: '1.5'
         outcome: 'success'
-        price: 1.5
-        foo: 'bar'
-      assert.deepEqual response(vars, {}, xml(foo: 'bar')), expected
+      assert.deepEqual response(vars, {}, xml(bar: { cost: '1.5'})), expected
 
 
 

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -11,6 +11,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         foo: 'bar'
+        price: 0
       assert.deepEqual response({}, {}, json(foo: 'bar')), expected
 
 
@@ -18,6 +19,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_on_match: 'failure', {}, json(foo: 'bar')), expected
 
 
@@ -25,6 +27,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', {}, json(foo: 'bar')), expected
 
 
@@ -32,6 +35,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
@@ -39,6 +43,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'bip', {}, json(foo: 'bar')), expected
 
 
@@ -46,6 +51,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'bip', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
@@ -54,6 +60,7 @@ describe 'Response', ->
         outcome: 'failure'
         x: 'bip'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'bip', outcome_search_path: 'baz.bip', {}, json(x: 'bip', baz: { bip: 'foo'})), expected
 
 
@@ -61,6 +68,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, json(foo: 'bar')), expected
 
 
@@ -68,6 +76,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
@@ -75,6 +84,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         barfoobaz: 'bip'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', {}, json(barfoobaz: 'bip')), expected
 
 
@@ -82,6 +92,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
 
 
@@ -89,6 +100,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         barfoobaz: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, json(barfoobaz: 'bar')), expected
 
 
@@ -96,6 +108,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
 
 
@@ -103,6 +116,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         barfoobaz: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, json(barfoobaz: 'bar')), expected
 
 
@@ -110,6 +124,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
 
 
@@ -117,6 +132,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[/', {}, json(baz: { bip: 'foo'})), expected
 
 
@@ -124,27 +140,29 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[/', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
     it 'should find search term with case insensitive match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO'
-      assert.deepEqual response(outcome_search_term: 'FOO', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepEqual response(outcome_search_term: 'FOO', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should find search term with case insensitive match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'baz', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO'
-      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: 'baz', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'baz', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: 'baz', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: 'bar')), outcome: 'failure', baz: 'bar'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: 'bar')), outcome: 'failure', baz: 'bar', price: 0
 
 
     it 'should not find match at path', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'bar' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: { bip: 'bar' })), expected
 
 
@@ -156,6 +174,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'the reason text!'
         baz: { bip: 'the reason text!' }
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { bip: 'the reason text!'})), expected
 
 
@@ -166,6 +185,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: '' }
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { bip: ''})), expected
 
 
@@ -176,6 +196,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: '     ' }
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { bip: '     '})), expected
 
 
@@ -187,6 +208,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'another reason, the reason text!'
         baz: { bip: ['the reason text!', 'another reason'] }
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
 
 
@@ -198,6 +220,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'another reason'
         baz: { bip: ['the reason text!', 'another reason'] }
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
 
 
@@ -208,6 +231,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         reason: 'the reason text!'
+        price: 0
       assert.deepEqual response(vars, {}, json( [ {bip: 'the reason text!'} ] )), expected
 
 
@@ -216,6 +240,7 @@ describe 'Response', ->
         outcome: 'success'
         reason: 'just because'
         baz: 'bip'
+        price: 0
       assert.deepEqual response(default_reason: 'just because', {}, json(baz: 'bip')), expected
 
 
@@ -226,6 +251,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { bip: 'foo' })), expected
 
 
@@ -238,6 +264,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'just because'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { bip: 'foo' })), expected
 
     it 'should successfully parse reason with wildcard in path', ->
@@ -250,7 +277,7 @@ describe 'Response', ->
         baz:
           foo:
             details: 'bad data'
-
+        price: 0
       assert.deepEqual response(vars, {}, json(baz: { foo: { details: 'bad data' }})), expected
 
     it 'should successfully parse reason with multiple wildcards in path', ->
@@ -265,6 +292,7 @@ describe 'Response', ->
             details:
               bip:
                 more_details: 'really bad data'
+        price: 0
          
       assert.deepEqual response(vars, {}, json(baz: { foo: { details: { bip: { more_details : 'really bad data'}}}})), expected
 
@@ -299,6 +327,7 @@ describe 'Response', ->
         err: 1
         message: "PhoneNumber is a required field."
         reason: "PhoneNumber is a required field."
+        price: 0
       assert.deepEqual response(vars, {}, res), expected
 
     it 'should capture price on success', ->
@@ -316,7 +345,7 @@ describe 'Response', ->
   describe 'with plain text body', ->
 
     it 'should include response body in event object', ->
-      assert.deepEqual response({}, {}, text('foo')), outcome: 'success'
+      assert.deepEqual response({}, {}, text('foo')), outcome: 'success', price: 0
 
 
     it 'should default to success without search term', ->
@@ -367,22 +396,22 @@ describe 'Response', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!', price: 0
 
 
     it 'should parse reason with slashes', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '/[a-z]+:(.*)/'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!', price: 0
 
 
     it 'should discard empty reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:')), outcome: 'failure'
-      assert.deepEqual response(vars, {}, text('bad:     ')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:')), outcome: 'failure', price: 0
+      assert.deepEqual response(vars, {}, text('bad:     ')), outcome: 'failure', price: 0
 
 
     it 'should return default reason', ->
@@ -393,7 +422,7 @@ describe 'Response', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', price: 0
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -401,7 +430,7 @@ describe 'Response', ->
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
         default_reason: 'just because'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'just because'
+      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'just because', price: 0
 
 
     it 'should use capture groups', ->
@@ -414,6 +443,7 @@ describe 'Response', ->
         outcome: 'failure'
         bad: 'the reason text!'
         why: 'just because'
+        price: 0
 
       assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), expected
 
@@ -423,7 +453,7 @@ describe 'Response', ->
         outcome_on_match: 'failure'
         capture:
           bad: '/bad: (.*/x'
-      assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), outcome: 'failure', price: 0
 
 
     it 'should revert to string search on non-text body', ->
@@ -443,98 +473,98 @@ describe 'Response', ->
   describe 'with html', ->
 
     it 'should default to success without search term', ->
-      assert.deepEqual response({}, {}, html('<div>foo</div>')), outcome: 'success'
+      assert.deepEqual response({}, {}, html('<div>foo</div>')), outcome: 'success', price: 0
 
 
     it 'should default to failure per outcome on match', ->
-      assert.deepEqual response(outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should find search term with exact match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div>foo</div>')), outcome: 'success'
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<foo>bar</foo>')), outcome: 'success'
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div id="foo">bar</div>')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div>foo</div>')), outcome: 'success', price: 0
+      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<foo>bar</foo>')), outcome: 'success', price: 0
+      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div id="foo">bar</div>')), outcome: 'success', price: 0
 
 
     it 'should find search term with exact match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success'
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div span', {}, html('<div><span>foo</span></foo>')), outcome: 'success'
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div[id="bar"]', {}, html('<div id="bar">foo</div>')), outcome: 'success'
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div><div>foo</div>')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success', price: 0
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div span', {}, html('<div><span>foo</span></foo>')), outcome: 'success', price: 0
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div[id="bar"]', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div><div>foo</div>')), outcome: 'success', price: 0
 
 
     it 'should not find search term', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div>bar</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div>bar</div>')), outcome: 'failure', price: 0
 
 
     it 'should not find search term at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div>')), outcome: 'failure', price: 0
 
 
     it 'should not find search term at different path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div[id="one"]', {}, html('<div id="one">bar</div><div id="other">foo</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div[id="one"]', {}, html('<div id="one">bar</div><div id="other">foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should return failure on match per outcome on match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should return failure on match per outcome on match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should find search term with partial match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('barfoobaz')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, html('barfoobaz')), outcome: 'success', price: 0
 
 
     it 'should find search term with partial match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>barfoobaz</div>')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>barfoobaz</div>')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex', ->
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, html('bazfoobar')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, html('bazfoobar')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex at path', ->
-      assert.deepEqual response(outcome_search_term: 'id="[a-z]+">foo<', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'id="[a-z]+">foo<', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex including slashes', ->
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, html('bazfoobar')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, html('bazfoobar')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex including slashes at path', ->
-      assert.deepEqual response(outcome_search_term: '/id="[a-z]+">foo</', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: '/id="[a-z]+">foo</', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
 
 
     it 'should not error on invalid regex search term', ->
-      assert.deepEqual response(outcome_search_term: '/[/', {}, html('foo')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: '/[/', {}, html('foo')), outcome: 'failure', price: 0
 
 
     it 'should not error on invalid regex search term at path', ->
-      assert.deepEqual response(outcome_search_term: '/[/', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: '/[/', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should find search term with case insensitive match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('FOO')), outcome: 'success'
-      assert.deepEqual response(outcome_search_term: 'FOO', {}, html('foo')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, html('FOO')), outcome: 'success', price: 0
+      assert.deepEqual response(outcome_search_term: 'FOO', {}, html('foo')), outcome: 'success', price: 0
 
 
     it 'should find search term with case insensitive match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>FOO</div>')), outcome: 'success'
-      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>FOO</div>')), outcome: 'success', price: 0
+      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success', price: 0
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('baz')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, html('baz')), outcome: 'failure', price: 0
 
 
     it 'should not find match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>baz</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>baz</div>')), outcome: 'failure', price: 0
 
 
     it 'should not error on broken html', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<dibaz</div>')), outcome: 'failure'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<dibaz</div>')), outcome: 'failure', price: 0
 
 
     it 'should parse reason', ->
@@ -544,6 +574,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         reason: 'just because'
+        price: 0
       assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message">just because</div>')), expected
 
 
@@ -554,6 +585,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         reason: 'just because'
+        price: 0
       assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message" reason="just because"></div>')), expected
 
 
@@ -561,14 +593,14 @@ describe 'Response', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'div[id="message"]'
-      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message"></div>')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message"></div>')), outcome: 'failure', price: 0
 
 
     it 'should discard whitespace reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'div[id="message"]'
-      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message">      </div>')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message">      </div>')), outcome: 'failure', price: 0
 
 
     it 'should parse multiple reasons', ->
@@ -578,6 +610,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         reason: 'another reason, the reason text!'
+        price: 0
       assert.deepEqual response(vars, {}, html('<div class="message">the reason text!</div><div class="message">another reason</div>')), expected
 
 
@@ -585,6 +618,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         reason: 'just because'
+        price: 0
       assert.deepEqual response(default_reason: 'just because', {}, html()), expected
 
 
@@ -592,7 +626,7 @@ describe 'Response', ->
       vars =
         outcome_search_term: 'bar'
         reason_path: 'div.message'
-      assert.deepEqual response(vars, {}, html('foo')), outcome: 'failure'
+      assert.deepEqual response(vars, {}, html('foo')), outcome: 'failure', price: 0
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -600,7 +634,7 @@ describe 'Response', ->
         outcome_search_term: 'bar'
         reason_path: 'div.message'
         default_reason: 'just because'
-      assert.deepEqual response(vars, {}, html('foo')), outcome: 'failure', reason: 'just because'
+      assert.deepEqual response(vars, {}, html('foo')), outcome: 'failure', reason: 'just because', price: 0
 
 
     it 'should revert to string search on non-HTML body', ->
@@ -617,7 +651,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         number_records: '42'
-
+        price: 0
       assert.deepEqual response(vars, {}, html('<div>result: matched 42 records.</div>')), expected
 
     it 'should capture price when price_path is present', ->
@@ -628,13 +662,13 @@ describe 'Response', ->
         price: "1.5"
       assert.deepEqual response(vars, {}, html('<div class="cost">1.5</div>')), expected
 
-
   describe 'with xml body', ->
 
     it 'should default to success without search term', ->
       expected =
         outcome: 'success'
         foo: 'bar'
+        price: 0
       assert.deepEqual response({}, {}, xml(foo: 'bar')), expected
 
 
@@ -642,6 +676,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_on_match: 'failure', {}, xml(foo: 'bar')), expected
 
 
@@ -649,6 +684,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', {}, xml(foo: 'bar')), expected
 
 
@@ -656,6 +692,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
@@ -663,6 +700,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'bip', {}, xml(foo: 'bar')), expected
 
 
@@ -670,12 +708,14 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'bip', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
     it 'should not find search term at different path', ->
       expected =
         outcome: 'failure'
+        price: 0
         y:
           x: 'bip'
           baz: { bip: 'foo' }
@@ -686,6 +726,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         foo: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, xml(foo: 'bar')), expected
 
 
@@ -693,6 +734,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
@@ -700,6 +742,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         barfoobaz: 'bip'
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', {}, xml(barfoobaz: 'bip')), expected
 
 
@@ -707,6 +750,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
 
 
@@ -714,6 +758,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         barfoobaz: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, xml(barfoobaz: 'bar')), expected
 
 
@@ -721,6 +766,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
 
 
@@ -728,6 +774,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         barfoobaz: 'bar'
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, xml(barfoobaz: 'bar')), expected
 
 
@@ -735,6 +782,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
 
 
@@ -742,6 +790,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[/', {}, xml(baz: { bip: 'foo'})), expected
 
 
@@ -749,27 +798,29 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(outcome_search_term: '/[/', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
     it 'should find search term with case insensitive match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO'
-      assert.deepEqual response(outcome_search_term: 'FOO', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepEqual response(outcome_search_term: 'FOO', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should find search term with case insensitive match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/baz', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO'
-      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: '/baz', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo'
+      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/baz', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: '/baz', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(baz: 'bar')), outcome: 'failure', baz: 'bar'
+      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(baz: 'bar')), outcome: 'failure', baz: 'bar', price: 0
 
 
     it 'should not find match at path', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'bar' }
+        price: 0
       assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/bip/text()', {}, xml(baz: { bip: 'bar' })), expected
 
 
@@ -781,6 +832,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'the reason text!'
         baz: { bip: 'the reason text!' }
+        price: 0
       assert.deepEqual response(vars, {}, xml(baz: { bip: 'the reason text!'})), expected
 
 
@@ -814,6 +866,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: '' }
+        price: 0
       assert.deepEqual response(vars, {}, xml(baz: { bip: ''})), expected
 
 
@@ -824,6 +877,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: '     ' }
+        price: 0
       assert.deepEqual response(vars, {}, xml(baz: { bip: '     '})), expected
 
 
@@ -835,6 +889,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'another reason, the reason text!'
         baz: { bip: ['the reason text!', 'another reason'] }
+        price: 0
       assert.deepEqual response(vars, {}, xml(baz: { bip: ['the reason text!', 'another reason']})), expected
 
 
@@ -843,6 +898,7 @@ describe 'Response', ->
         outcome: 'success'
         reason: 'just because'
         baz: 'bip'
+        price: 0
       assert.deepEqual response(default_reason: 'just because', {}, xml(baz: 'bip')), expected
 
 
@@ -853,6 +909,7 @@ describe 'Response', ->
       expected =
         outcome: 'failure'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(vars, {}, xml(baz: { bip: 'foo' })), expected
 
 
@@ -865,6 +922,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'just because'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(vars, {}, xml(baz: { bip: 'foo' })), expected
 
 
@@ -877,6 +935,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'just because'
         baz: { bip: 'foo' }
+        price: 0
       assert.deepEqual response(vars, {}, xml(baz: { bip: 'foo' })), expected
 
 
@@ -884,7 +943,7 @@ describe 'Response', ->
       vars = outcome_search_term: 'bar'
       res = json(foo: { bar: 'baz'})
       res.headers['Content-Type'] = 'text/xml'
-      assert.deepEqual response(vars, {}, res), outcome: 'success'
+      assert.deepEqual response(vars, {}, res), outcome: 'success', price: 0
 
     it 'should capture price', ->
       vars =
@@ -895,8 +954,6 @@ describe 'Response', ->
           cost: '1.5'
         outcome: 'success'
       assert.deepEqual response(vars, {}, xml(bar: { cost: '1.5'})), expected
-
-
 
   describe 'HTTP status code', ->
 
@@ -948,7 +1005,6 @@ describe 'Response', ->
         body: ''
       assert.deepEqual response({outcome_search_term: null, outcome_on_match: null}, {}, res).outcome, 'success'
 
-
   describe 'cookie capture', ->
 
     before ->
@@ -959,28 +1015,28 @@ describe 'Response', ->
           'Set-Cookie': @cookie
 
     it 'should not capture anything with no search-term', ->
-      assert.deepEqual response({}, {}, @res), outcome: 'success'
+      assert.deepEqual response({}, {}, @res), outcome: 'success', price: 0
 
 
     it 'should not capture anything when search-term does not match', ->
-      assert.deepEqual response(cookie_search_term: 'login_info', {}, @res), outcome: 'success'
+      assert.deepEqual response(cookie_search_term: 'login_info', {}, @res), outcome: 'success', price: 0
 
 
     it 'should not capture anything when regex search-term does not match', ->
-      assert.deepEqual response(cookie_search_term: 'domain=.x[0-9]{7}', {}, @res), outcome: 'success'
+      assert.deepEqual response(cookie_search_term: 'domain=.x[0-9]{7}', {}, @res), outcome: 'success', price: 0
 
 
     it 'should capture a cookie that matches string search-term', ->
-      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie
+      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie, price: 0
 
 
     it 'should capture a cookie regardless of search-term case', ->
-      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie
-      assert.deepEqual response(cookie_search_term: 'SESSION_ID', {}, @res), outcome: 'success', cookie: @cookie
+      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie, price: 0
+      assert.deepEqual response(cookie_search_term: 'SESSION_ID', {}, @res), outcome: 'success', cookie: @cookie, price: 0
 
 
     it 'should capture a cookie that matches regex search-term', ->
-      assert.deepEqual response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: @cookie
+      assert.deepEqual response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: @cookie, price: 0
 
 
     it 'should capture the first cookie (sorted lexicographically) when multiples match string search-term', ->
@@ -991,7 +1047,7 @@ describe 'Response', ->
         cookie2
         cookie3
       ]
-      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: cookie2
+      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: cookie2, price: 0
 
     it 'should capture the first cookie (sorted lexicographically) when multiples match regex search-term', ->
       cookie2 = 'Session_id=123; path=/; domain=.fizzbuzz.com; expires=Sat, 01-Jan-2022 16:39:03 GMT; Max-Age=155520000; secure; httpOnly'
@@ -1001,7 +1057,7 @@ describe 'Response', ->
         cookie2
         cookie3
       ]
-      assert.deepEqual response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: cookie2
+      assert.deepEqual response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: cookie2, price: 0
 
 
 xml = (obj) ->

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -302,11 +302,12 @@ describe 'Response', ->
       assert.deepEqual response(vars, {}, res), expected
 
     it 'should capture price when vars.price is defined', ->
+      vars = cost: 1.5
       expected =
         outcome: 'success'
         foo: 'bar'
         price: 1.5
-      assert.deepEqual response(cost: 1.5, {}, json(foo: 'bar')), expected
+      assert.deepEqual response(vars, {}, json(foo: 'bar')), expected
  
 
   describe 'with plain text body', ->
@@ -880,7 +881,7 @@ describe 'Response', ->
       res.headers['Content-Type'] = 'text/xml'
       assert.deepEqual response(vars, {}, res), outcome: 'success'
 
-    it 'should default to success without search term', ->
+    it 'should capture price when vars.cost is present', ->
       vars = cost: 1.5
       expected =
         outcome: 'success'

--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -300,6 +300,13 @@ describe 'Response', ->
         message: "PhoneNumber is a required field."
         reason: "PhoneNumber is a required field."
       assert.deepEqual response(vars, {}, res), expected
+
+    it 'should capture price when vars.price is defined', ->
+      expected =
+        outcome: 'success'
+        foo: 'bar'
+        price: 1.5
+      assert.deepEqual response(cost: 1.5, {}, json(foo: 'bar')), expected
  
 
   describe 'with plain text body', ->
@@ -421,7 +428,12 @@ describe 'Response', ->
       res.headers['Content-Type'] = 'plain/text'
       assert.deepEqual response(vars, {}, res).outcome, 'success'
 
-
+    it 'should capture price when vars.cost is present', ->
+      vars = cost: 1.5
+      expected = 
+        outcome: 'success'
+        price: 1.5
+      assert.deepEqual response(vars, {}, text('foo')), expected
 
   describe 'with html', ->
 
@@ -603,6 +615,13 @@ describe 'Response', ->
 
       assert.deepEqual response(vars, {}, html('<div>result: matched 42 records.</div>')), expected
 
+    it 'should capture price when vars.cost is present', ->
+      vars = cost: 1.5
+      expected = 
+        outcome: 'success'
+        price: 1.5
+      assert.deepEqual response(vars, {}, html('<div>foo</div>')), expected
+
 
   describe 'with xml body', ->
 
@@ -610,7 +629,7 @@ describe 'Response', ->
       expected =
         outcome: 'success'
         foo: 'bar'
-      assert.deepEqual response({}, {}, json(foo: 'bar')), expected
+      assert.deepEqual response({}, {}, xml(foo: 'bar')), expected
 
 
     it 'should default to failure per outcome on match', ->
@@ -860,6 +879,14 @@ describe 'Response', ->
       res = json(foo: { bar: 'baz'})
       res.headers['Content-Type'] = 'text/xml'
       assert.deepEqual response(vars, {}, res), outcome: 'success'
+
+    it 'should default to success without search term', ->
+      vars = cost: 1.5
+      expected =
+        outcome: 'success'
+        price: 1.5
+        foo: 'bar'
+      assert.deepEqual response(vars, {}, xml(foo: 'bar')), expected
 
 
 

--- a/spec/soap-spec.coffee
+++ b/spec/soap-spec.coffee
@@ -745,6 +745,14 @@ describe 'Outbound SOAP', ->
               Foo: [ '1', '2' ]
         done()
 
+    it 'should capture price when vars.cost is present', (done) ->
+      @vars.cost = 1.5
+      soap.handle @vars, (err, event) =>
+        return done(err) if err
+        assert.equal event.outcome, 'success'
+        assert.equal event.price, 1.5
+        done()
+
 
   describe 'validation', ->
 

--- a/spec/soap-spec.coffee
+++ b/spec/soap-spec.coffee
@@ -450,6 +450,7 @@ describe 'Outbound SOAP', ->
           Message: 'some message'
           LeadId: 12345
           Empty: null
+          Cost: "1.5"
           Multi:
             Foo: [ '1', '2' ]
         done()
@@ -745,8 +746,8 @@ describe 'Outbound SOAP', ->
               Foo: [ '1', '2' ]
         done()
 
-    it 'should capture price when vars.cost is present', (done) ->
-      @vars.cost = 1.5
+    it 'should capture price', (done) ->
+      @vars.price_path = 'AddLeadResult.Cost'
       soap.handle @vars, (err, event) =>
         return done(err) if err
         assert.equal event.outcome, 'success'

--- a/spec/soap-success.xml
+++ b/spec/soap-success.xml
@@ -6,6 +6,7 @@
                 <Result>true</Result>
                 <Message>some message</Message>
                 <LeadId>12345</LeadId>
+                <Cost>1.5</Cost>
                 <Empty/>
                 <Multi>
                     <Foo>1</Foo>

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -69,8 +69,6 @@ response = (vars, req, res) ->
     
 
   else
-    # price is sent as 0 in non-success cases
-    price = 0
     # narrow the search scope
     searchIn =
       if searchPath
@@ -163,8 +161,6 @@ response = (vars, req, res) ->
 
   price = ensureArray(price)
     .map(extractCData)[0]
-    
-
 
   # build the event
   event =
@@ -190,7 +186,7 @@ response = (vars, req, res) ->
 
   event ?= {}
   event.outcome = outcome
-  event.price = price if price
+  event.price = price || 0
   event.reason = reason if reason
   event.cookie = cookie if cookie
 

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -151,6 +151,7 @@ response = (vars, req, res) ->
   event.outcome = outcome
   event.reason = reason if reason
   event.cookie = cookie if cookie
+  event.price = vars.cost.valueOf() if vars.cost?
 
   # return the event
   event
@@ -161,6 +162,7 @@ response.variables = ->
     { name: 'outcome', type: 'string', description: 'The outcome of the transaction (default is success)' }
     { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' }
     { name: 'cookie', type: 'string', description: 'The full cookie header string captured via match with \'cookie_search_term\'' }
+    { name: 'price', type: 'number', description: 'The price of the lead' }
     { name: '*', type: 'wildcard' }
   ]
 

--- a/src/soap.coffee
+++ b/src/soap.coffee
@@ -147,8 +147,6 @@ handle = (vars, callback) ->
       price = 
         if outcome == 'success'
           _.get(result, priceSelector)
-        else
-          0
 
 
       # determine the reason based on the reason selector
@@ -172,7 +170,7 @@ handle = (vars, callback) ->
       event = result
       event.outcome = outcome
       event.reason = reason if reason
-      event.price = price if price
+      event.price = price || 0
 
       # return the event
       callback null, event

--- a/src/soap.coffee
+++ b/src/soap.coffee
@@ -122,6 +122,7 @@ handle = (vars, callback) ->
       searchOutcome = vars.outcome_on_match?.trim().toLowerCase() ? 'success'
       searchPath = vars.outcome_search_path?.trim()
       reasonSelector = vars.reason_path?.trim()
+      priceSelector = vars.price_path?.trim()
 
       # narrow the search scope
       searchIn =
@@ -142,6 +143,13 @@ handle = (vars, callback) ->
           searchOutcome
         else
           inverseOutcome(searchOutcome)
+
+      price = 
+        if outcome == 'success'
+          _.get(result, priceSelector)
+        else
+          0
+
 
       # determine the reason based on the reason selector
       reasons =
@@ -164,7 +172,7 @@ handle = (vars, callback) ->
       event = result
       event.outcome = outcome
       event.reason = reason if reason
-      event.price = vars.cost.valueOf() if vars.cost?
+      event.price = price if price
 
       # return the event
       callback null, event

--- a/src/soap.coffee
+++ b/src/soap.coffee
@@ -164,6 +164,7 @@ handle = (vars, callback) ->
       event = result
       event.outcome = outcome
       event.reason = reason if reason
+      event.price = vars.cost.valueOf() if vars.cost?
 
       # return the event
       callback null, event
@@ -225,6 +226,7 @@ responseVariables = ->
   [
     { name: 'outcome', type: 'string', description: 'The outcome of the SOAP transaction (default is success)' }
     { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' }
+    { name: 'price', type: 'number', description: 'The price of the lead' }
     { name: '*', type: 'wildcard' }
   ]
 

--- a/src/soap.coffee
+++ b/src/soap.coffee
@@ -221,6 +221,7 @@ requestVariables = ->
     { name: 'outcome_search_path', description: 'Narrow the search scope using dot-notation path', type: 'string', required: false }
     { name: 'outcome_on_match', description: 'The outcome when the search term is found - "success" or "failure" (default: success)', type: 'string', required: false }
     { name: 'reason_path', description: 'The dot-notation path used to find the failure reason', type: 'string', required: false }
+    { name: 'price_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the lead price', type: 'string', required: false }
     { name: 'default_reason', description: 'Failure reason when no reason can be found per the optional Reason Path setting', type: 'string', required: false }
     { name: 'soap_header.*', description: 'Custom SOAP header in the format root_name.header_name or root_name@xmlns', type: 'wildcard', required: false }
     { name: 'send_ascii', description: 'Set to true to ensure lead data is sent as ASCII for legacy recipients (default: false)', type: 'boolean', required: false }

--- a/src/variables.coffee
+++ b/src/variables.coffee
@@ -3,6 +3,7 @@ module.exports = [
   { name: 'outcome_search_path', description: 'Narrow the search scope using dot-notation path (for JSON responses), XPath (for XML responses), or CSS selector (for HTML responses)', type: 'string', required: false }
   { name: 'outcome_on_match', description: 'The outcome when the search term is found - "success" or "failure" (default: success)', type: 'string', required: false }
   { name: 'reason_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the failure reason', type: 'string', required: false }
+  { name: 'price_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the lead price', type: 'string', required: false }
   { name: 'default_reason', description: 'Failure reason when no reason can be found per the optional Reason Path setting', type: 'string', required: false }
   { name: 'header.*', description: 'HTTP header to send in the request', type: 'wildcard', required: false }
   { name: 'send_ascii', description: 'Set to true to ensure lead data is sent as ASCII for legacy recipients (default: false)', type: 'boolean', required: false }


### PR DESCRIPTION
This supports capturing the `price` response variable for the JSON, XML, SOAP, and Form POST integrations.

Here's the [ticket](https://activeprospect.tpondemand.com/entity/6123-update-json-xml-soap-form-post) for (a little) more context.