### PR TITLE
Guard against undefined with bogus searchpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.18.1] - 2018-08-28
+## [2.18.2] - 2018-08-28
 ### Fixed
 - Guard against bogus searchpath
+
+## [2.18.1] - 2018-10-31
+### Added
+- Capture 'price' response variable
 
 ## [2.17.0] - 2018-08-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.18.2] - 2018-08-28
+## [2.18.1] - 2018-08-28
 ### Fixed
 - Guard against bogus searchpath
 
-## [2.18.1] - 2018-10-31
+## [2.18.0] - 2018-10-31
 ### Added
 - Capture 'price' response variable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.18.0] - 2018-10-31
-### Added
-- Capture 'price' response variable
+## [2.18.1] - 2018-08-28
+### Fixed
+- Guard against bogus searchpath
 
 ## [2.17.0] - 2018-08-28
 ### Added

--- a/spec/soap-spec.coffee
+++ b/spec/soap-spec.coffee
@@ -506,6 +506,13 @@ describe 'Outbound SOAP', ->
         assert.equal event.outcome, 'failure'
         done()
 
+    it 'should not bonk with bogus search path', (done) ->
+      @vars.outcome_search_path = '0'
+      @vars.outcome_search_term = 'foo'
+      soap.handle @vars, (err, event) =>
+        return done(err) if err
+        assert.equal event.outcome, 'failure'
+        done()
 
     it 'should not find search term at different path', (done) ->
       @vars.outcome_search_path = 'AddLeadResult.Result'

--- a/spec/soap-spec.coffee
+++ b/spec/soap-spec.coffee
@@ -509,10 +509,12 @@ describe 'Outbound SOAP', ->
     it 'should not bonk with bogus search path', (done) ->
       @vars.outcome_search_path = '0'
       @vars.outcome_search_term = 'foo'
-      soap.handle @vars, (err, event) =>
-        return done(err) if err
-        assert.equal event.outcome, 'failure'
-        done()
+
+      invokeHandle = () =>
+        soap.handle @vars, (err, event) => 
+
+      assert.doesNotThrow invokeHandle
+      done()
 
     it 'should not find search term at different path', (done) ->
       @vars.outcome_search_path = 'AddLeadResult.Result'

--- a/src/soap.coffee
+++ b/src/soap.coffee
@@ -128,7 +128,7 @@ handle = (vars, callback) ->
       searchIn =
         if searchPath
           # limit outcome_search_term to this path in the document
-          _.get(result, searchPath).toString()
+          _.get(result, searchPath)?.toString()
 
         else
           # no search path was provided, so search the entire response body


### PR DESCRIPTION
When given a wonky `search_path`, the integration bonks: https://next.leadconduit.com/events/5be4c2c9d65e852e8b5fb863/5be4c2c9d65e852e8b5fb864

The test for this feels lame. I tried using `assert.doesNotThrow` but couldn't figure out how it works. Any suggestions? 

Note to self: Add a changelog note