### PR TITLE
Jarrodmiller/ch4126/response media authentication

### DIFF
--- a/spec/response-spec.coffee
+++ b/spec/response-spec.coffee
@@ -12,7 +12,7 @@ describe 'Response', ->
         outcome: 'success'
         foo: 'bar'
         price: 0
-      assert.deepEqual response({}, {}, json(foo: 'bar')), expected
+      assert.deepInclude response({}, {}, json(foo: 'bar')), expected
 
 
     it 'should default to failure per outcome on match', ->
@@ -20,7 +20,7 @@ describe 'Response', ->
         outcome: 'failure'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_on_match: 'failure', {}, json(foo: 'bar')), expected
+      assert.deepInclude response(outcome_on_match: 'failure', {}, json(foo: 'bar')), expected
 
 
     it 'should find search term with exact match', ->
@@ -28,7 +28,7 @@ describe 'Response', ->
         outcome: 'success'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', {}, json(foo: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: 'foo', {}, json(foo: 'bar')), expected
 
 
     it 'should find search term with exact match at path', ->
@@ -36,7 +36,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
     it 'should not find search term', ->
@@ -44,7 +44,7 @@ describe 'Response', ->
         outcome: 'failure'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'bip', {}, json(foo: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: 'bip', {}, json(foo: 'bar')), expected
 
 
     it 'should not find search term at path', ->
@@ -52,7 +52,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'bip', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: 'bip', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
     it 'should not find search term at different path', ->
@@ -61,7 +61,7 @@ describe 'Response', ->
         x: 'bip'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'bip', outcome_search_path: 'baz.bip', {}, json(x: 'bip', baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: 'bip', outcome_search_path: 'baz.bip', {}, json(x: 'bip', baz: { bip: 'foo'})), expected
 
 
     it 'should return failure on match per outcome on match', ->
@@ -69,7 +69,7 @@ describe 'Response', ->
         outcome: 'failure'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, json(foo: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, json(foo: 'bar')), expected
 
 
     it 'should return failure on match per outcome on match at path', ->
@@ -77,7 +77,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
     it 'should find search term with partial match', ->
@@ -85,7 +85,7 @@ describe 'Response', ->
         outcome: 'success'
         barfoobaz: 'bip'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', {}, json(barfoobaz: 'bip')), expected
+      assert.deepInclude response(outcome_search_term: 'foo', {}, json(barfoobaz: 'bip')), expected
 
 
     it 'should find search term with partial match at path', ->
@@ -93,7 +93,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
 
 
     it 'should find search term with regex', ->
@@ -101,7 +101,7 @@ describe 'Response', ->
         outcome: 'success'
         barfoobaz: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, json(barfoobaz: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, json(barfoobaz: 'bar')), expected
 
 
     it 'should find search term with regex at path', ->
@@ -109,7 +109,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
+      assert.deepInclude response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
 
 
     it 'should find search term with regex including slashes', ->
@@ -117,7 +117,7 @@ describe 'Response', ->
         outcome: 'success'
         barfoobaz: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, json(barfoobaz: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, json(barfoobaz: 'bar')), expected
 
 
     it 'should find search term with regex with slashes at path', ->
@@ -125,7 +125,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
+      assert.deepInclude response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'barfoobaz' })), expected
 
 
     it 'should not error on invalid regex search term', ->
@@ -133,7 +133,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[/', {}, json(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: '/[/', {}, json(baz: { bip: 'foo'})), expected
 
 
     it 'should not error on invalid regex search term at path', ->
@@ -141,21 +141,21 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[/', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: '/[/', outcome_search_path: 'baz.bip', {}, json(baz: { bip: 'foo'})), expected
 
 
     it 'should find search term with case insensitive match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
-      assert.deepEqual response(outcome_search_term: 'FOO', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepInclude response(outcome_search_term: 'FOO', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should find search term with case insensitive match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'baz', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
-      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: 'baz', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'baz', {}, json(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepInclude response(outcome_search_term: 'FOO', outcome_search_path: 'baz', {}, json(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: 'bar')), outcome: 'failure', baz: 'bar', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, json(baz: 'bar')), outcome: 'failure', baz: 'bar', price: 0
 
 
     it 'should not find match at path', ->
@@ -163,7 +163,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'bar' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', {}, json(baz: { bip: 'bar' })), expected
+      assert.deepInclude response(outcome_search_term: 'foo', {}, json(baz: { bip: 'bar' })), expected
 
 
     it 'should parse reason', ->
@@ -175,7 +175,7 @@ describe 'Response', ->
         reason: 'the reason text!'
         baz: { bip: 'the reason text!' }
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { bip: 'the reason text!'})), expected
+      assert.deepInclude response(vars, {}, json(baz: { bip: 'the reason text!'})), expected
 
 
     it 'should discard empty reason', ->
@@ -186,7 +186,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: '' }
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { bip: ''})), expected
+      assert.deepInclude response(vars, {}, json(baz: { bip: ''})), expected
 
 
     it 'should discard whitespace reason', ->
@@ -197,7 +197,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: '     ' }
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { bip: '     '})), expected
+      assert.deepInclude response(vars, {}, json(baz: { bip: '     '})), expected
 
 
     it 'should parse multiple reasons', ->
@@ -209,7 +209,7 @@ describe 'Response', ->
         reason: 'another reason, the reason text!'
         baz: { bip: ['the reason text!', 'another reason'] }
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
+      assert.deepInclude response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
 
 
     it 'should parse single reason from array', ->
@@ -221,7 +221,7 @@ describe 'Response', ->
         reason: 'another reason'
         baz: { bip: ['the reason text!', 'another reason'] }
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
+      assert.deepInclude response(vars, {}, json(baz: { bip: ['the reason text!', 'another reason']})), expected
 
 
     it 'should parse reason from array response', ->
@@ -232,7 +232,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'the reason text!'
         price: 0
-      assert.deepEqual response(vars, {}, json( [ {bip: 'the reason text!'} ] )), expected
+      assert.deepInclude response(vars, {}, json( [ {bip: 'the reason text!'} ] )), expected
 
 
     it 'should return default reason', ->
@@ -241,7 +241,7 @@ describe 'Response', ->
         reason: 'just because'
         baz: 'bip'
         price: 0
-      assert.deepEqual response(default_reason: 'just because', {}, json(baz: 'bip')), expected
+      assert.deepInclude response(default_reason: 'just because', {}, json(baz: 'bip')), expected
 
 
     it 'should fail to parse reason', ->
@@ -252,7 +252,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { bip: 'foo' })), expected
+      assert.deepInclude response(vars, {}, json(baz: { bip: 'foo' })), expected
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -265,7 +265,7 @@ describe 'Response', ->
         reason: 'just because'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { bip: 'foo' })), expected
+      assert.deepInclude response(vars, {}, json(baz: { bip: 'foo' })), expected
 
     it 'should successfully parse reason with wildcard in path', ->
       vars =
@@ -278,7 +278,7 @@ describe 'Response', ->
           foo:
             details: 'bad data'
         price: 0
-      assert.deepEqual response(vars, {}, json(baz: { foo: { details: 'bad data' }})), expected
+      assert.deepInclude response(vars, {}, json(baz: { foo: { details: 'bad data' }})), expected
 
     it 'should successfully parse reason with multiple wildcards in path', ->
       vars =
@@ -294,14 +294,14 @@ describe 'Response', ->
                 more_details: 'really bad data'
         price: 0
          
-      assert.deepEqual response(vars, {}, json(baz: { foo: { details: { bip: { more_details : 'really bad data'}}}})), expected
+      assert.deepInclude response(vars, {}, json(baz: { foo: { details: { bip: { more_details : 'really bad data'}}}})), expected
 
 
     it 'should revert to string search on non-JSON body', ->
       vars = outcome_search_term: 'bar'
       res = xml(foo: 'bar')
       res.headers['Content-Type'] = 'application/json'
-      assert.deepEqual response(vars, {}, res).outcome, 'success'
+      assert.deepInclude response(vars, {}, res).outcome, 'success'
 
 
     it 'should revert to regex on non-JSON body', ->
@@ -328,7 +328,7 @@ describe 'Response', ->
         message: "PhoneNumber is a required field."
         reason: "PhoneNumber is a required field."
         price: 0
-      assert.deepEqual response(vars, {}, res), expected
+      assert.deepInclude response(vars, {}, res), expected
 
     it 'should capture price on success', ->
       vars = 
@@ -339,90 +339,90 @@ describe 'Response', ->
         baz:
           foo:
             cost: 1.5
-      assert.deepEqual response(vars, {}, json(baz: { foo: { cost: 1.5 }})), expected
+      assert.deepInclude response(vars, {}, json(baz: { foo: { cost: 1.5 }})), expected
  
 
   describe 'with plain text body', ->
 
     it 'should include response body in event object', ->
-      assert.deepEqual response({}, {}, text('foo')), outcome: 'success', price: 0
+      assert.deepInclude response({}, {}, text('foo')), outcome: 'success', price: 0
 
 
     it 'should default to success without search term', ->
-      assert.deepEqual response({}, {}, text('foo')).outcome, 'success'
+      assert.deepInclude response({}, {}, text('foo')).outcome, 'success'
 
 
     it 'should default to failure per outcome on match', ->
-      assert.deepEqual response(outcome_on_match: 'failure', {}, text('foo')).outcome, 'failure'
+      assert.deepInclude response(outcome_on_match: 'failure', {}, text('foo')).outcome, 'failure'
 
 
     it 'should find search term with exact match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('foo')).outcome, 'success'
+      assert.deepInclude response(outcome_search_term: 'foo', {}, text('foo')).outcome, 'success'
 
 
     it 'should not find search term', ->
-      assert.deepEqual response(outcome_search_term: 'bip', {}, text('foo')).outcome, 'failure'
+      assert.deepInclude response(outcome_search_term: 'bip', {}, text('foo')).outcome, 'failure'
 
 
     it 'should return failure on match per outcome on match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, text('foo')).outcome, 'failure'
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, text('foo')).outcome, 'failure'
 
 
     it 'should find search term with partial match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('barfoobaz')).outcome, 'success'
+      assert.deepInclude response(outcome_search_term: 'foo', {}, text('barfoobaz')).outcome, 'success'
 
 
     it 'should find search term with regex', ->
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, text('barfoobaz')).outcome, 'success'
+      assert.deepInclude response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, text('barfoobaz')).outcome, 'success'
 
 
     it 'should find search term with regex including slashes', ->
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, text('barfoobaz')).outcome, 'success'
+      assert.deepInclude response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, text('barfoobaz')).outcome, 'success'
 
 
     it 'should not error on invalid regex search term', ->
-      assert.deepEqual response(outcome_search_term: '/[/', {}, text('foo')).outcome, 'failure'
+      assert.deepInclude response(outcome_search_term: '/[/', {}, text('foo')).outcome, 'failure'
 
 
     it 'should find search term with case insensitve match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('FOO')).outcome, 'success'
+      assert.deepInclude response(outcome_search_term: 'foo', {}, text('FOO')).outcome, 'success'
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, text('bar')).outcome, 'failure'
+      assert.deepInclude response(outcome_search_term: 'foo', {}, text('bar')).outcome, 'failure'
 
 
     it 'should parse reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!', price: 0
+      assert.deepInclude response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!', price: 0
 
 
     it 'should parse reason with slashes', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '/[a-z]+:(.*)/'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!', price: 0
+      assert.deepInclude response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'the reason text!', price: 0
 
 
     it 'should discard empty reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: '[a-z]+:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:')), outcome: 'failure', price: 0
-      assert.deepEqual response(vars, {}, text('bad:     ')), outcome: 'failure', price: 0
+      assert.deepInclude response(vars, {}, text('bad:')), outcome: 'failure', price: 0
+      assert.deepInclude response(vars, {}, text('bad:     ')), outcome: 'failure', price: 0
 
 
     it 'should return default reason', ->
-      assert.deepEqual response(default_reason: 'just because', {}, text('foo')).reason, 'just because'
+      assert.deepInclude response(default_reason: 'just because', {}, text('foo')).reason, 'just because'
 
 
     it 'should fail to parse reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', price: 0
+      assert.deepInclude response(vars, {}, text('bad:the reason text!')), outcome: 'failure', price: 0
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -430,7 +430,7 @@ describe 'Response', ->
         outcome_search_term: 'foo'
         reason_path: 'whatever:(.*)'
         default_reason: 'just because'
-      assert.deepEqual response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'just because', price: 0
+      assert.deepInclude response(vars, {}, text('bad:the reason text!')), outcome: 'failure', reason: 'just because', price: 0
 
 
     it 'should use capture groups', ->
@@ -445,7 +445,7 @@ describe 'Response', ->
         why: 'just because'
         price: 0
 
-      assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), expected
+      assert.deepInclude response(vars, {}, text('bad: the reason text!\nwhy: just because')), expected
 
 
     it 'should not choke on bad capture group', ->
@@ -453,7 +453,7 @@ describe 'Response', ->
         outcome_on_match: 'failure'
         capture:
           bad: '/bad: (.*/x'
-      assert.deepEqual response(vars, {}, text('bad: the reason text!\nwhy: just because')), outcome: 'failure', price: 0
+      assert.deepInclude response(vars, {}, text('bad: the reason text!\nwhy: just because')), outcome: 'failure', price: 0
 
 
     it 'should revert to string search on non-text body', ->
@@ -468,103 +468,103 @@ describe 'Response', ->
       expected = 
         outcome: 'success'
         price: '1.5'
-      assert.deepEqual response(vars, {}, text('foo&cost=1.5')), expected
+      assert.deepInclude response(vars, {}, text('foo&cost=1.5')), expected
 
   describe 'with html', ->
 
     it 'should default to success without search term', ->
-      assert.deepEqual response({}, {}, html('<div>foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response({}, {}, html('<div>foo</div>')), outcome: 'success', price: 0
 
 
     it 'should default to failure per outcome on match', ->
-      assert.deepEqual response(outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should find search term with exact match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div>foo</div>')), outcome: 'success', price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<foo>bar</foo>')), outcome: 'success', price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div id="foo">bar</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, html('<div>foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, html('<foo>bar</foo>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, html('<div id="foo">bar</div>')), outcome: 'success', price: 0
 
 
     it 'should find search term with exact match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success', price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div span', {}, html('<div><span>foo</span></foo>')), outcome: 'success', price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div[id="bar"]', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div><div>foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div span', {}, html('<div><span>foo</span></foo>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div[id="bar"]', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div><div>foo</div>')), outcome: 'success', price: 0
 
 
     it 'should not find search term', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('<div>bar</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, html('<div>bar</div>')), outcome: 'failure', price: 0
 
 
     it 'should not find search term at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>bar</div>')), outcome: 'failure', price: 0
 
 
     it 'should not find search term at different path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div[id="one"]', {}, html('<div id="one">bar</div><div id="other">foo</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div[id="one"]', {}, html('<div id="one">bar</div><div id="other">foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should return failure on match per outcome on match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should return failure on match per outcome on match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should find search term with partial match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('barfoobaz')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, html('barfoobaz')), outcome: 'success', price: 0
 
 
     it 'should find search term with partial match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>barfoobaz</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>barfoobaz</div>')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex', ->
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, html('bazfoobar')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, html('bazfoobar')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex at path', ->
-      assert.deepEqual response(outcome_search_term: 'id="[a-z]+">foo<', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'id="[a-z]+">foo<', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex including slashes', ->
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, html('bazfoobar')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, html('bazfoobar')), outcome: 'success', price: 0
 
 
     it 'should find search term with regex including slashes at path', ->
-      assert.deepEqual response(outcome_search_term: '/id="[a-z]+">foo</', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: '/id="[a-z]+">foo</', outcome_search_path: 'body', {}, html('<div id="bar">foo</div>')), outcome: 'success', price: 0
 
 
     it 'should not error on invalid regex search term', ->
-      assert.deepEqual response(outcome_search_term: '/[/', {}, html('foo')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: '/[/', {}, html('foo')), outcome: 'failure', price: 0
 
 
     it 'should not error on invalid regex search term at path', ->
-      assert.deepEqual response(outcome_search_term: '/[/', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: '/[/', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'failure', price: 0
 
 
     it 'should find search term with case insensitive match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('FOO')), outcome: 'success', price: 0
-      assert.deepEqual response(outcome_search_term: 'FOO', {}, html('foo')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, html('FOO')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'FOO', {}, html('foo')), outcome: 'success', price: 0
 
 
     it 'should find search term with case insensitive match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>FOO</div>')), outcome: 'success', price: 0
-      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>FOO</div>')), outcome: 'success', price: 0
+      assert.deepInclude response(outcome_search_term: 'FOO', outcome_search_path: 'div', {}, html('<div>foo</div>')), outcome: 'success', price: 0
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, html('baz')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, html('baz')), outcome: 'failure', price: 0
 
 
     it 'should not find match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>baz</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<div>baz</div>')), outcome: 'failure', price: 0
 
 
     it 'should not error on broken html', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<dibaz</div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: 'div', {}, html('<dibaz</div>')), outcome: 'failure', price: 0
 
 
     it 'should parse reason', ->
@@ -575,7 +575,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'just because'
         price: 0
-      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message">just because</div>')), expected
+      assert.deepInclude response(vars, {}, html('<div>bar</div><div id="message">just because</div>')), expected
 
 
     it 'should parse reason from attribute', ->
@@ -586,21 +586,21 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'just because'
         price: 0
-      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message" reason="just because"></div>')), expected
+      assert.deepInclude response(vars, {}, html('<div>bar</div><div id="message" reason="just because"></div>')), expected
 
 
     it 'should discard empty reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'div[id="message"]'
-      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message"></div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(vars, {}, html('<div>bar</div><div id="message"></div>')), outcome: 'failure', price: 0
 
 
     it 'should discard whitespace reason', ->
       vars =
         outcome_search_term: 'foo'
         reason_path: 'div[id="message"]'
-      assert.deepEqual response(vars, {}, html('<div>bar</div><div id="message">      </div>')), outcome: 'failure', price: 0
+      assert.deepInclude response(vars, {}, html('<div>bar</div><div id="message">      </div>')), outcome: 'failure', price: 0
 
 
     it 'should parse multiple reasons', ->
@@ -611,7 +611,7 @@ describe 'Response', ->
         outcome: 'failure'
         reason: 'another reason, the reason text!'
         price: 0
-      assert.deepEqual response(vars, {}, html('<div class="message">the reason text!</div><div class="message">another reason</div>')), expected
+      assert.deepInclude response(vars, {}, html('<div class="message">the reason text!</div><div class="message">another reason</div>')), expected
 
 
     it 'should return default reason', ->
@@ -619,14 +619,14 @@ describe 'Response', ->
         outcome: 'success'
         reason: 'just because'
         price: 0
-      assert.deepEqual response(default_reason: 'just because', {}, html()), expected
+      assert.deepInclude response(default_reason: 'just because', {}, html()), expected
 
 
     it 'should fail to parse reason', ->
       vars =
         outcome_search_term: 'bar'
         reason_path: 'div.message'
-      assert.deepEqual response(vars, {}, html('foo')), outcome: 'failure', price: 0
+      assert.deepInclude response(vars, {}, html('foo')), outcome: 'failure', price: 0
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -634,14 +634,14 @@ describe 'Response', ->
         outcome_search_term: 'bar'
         reason_path: 'div.message'
         default_reason: 'just because'
-      assert.deepEqual response(vars, {}, html('foo')), outcome: 'failure', reason: 'just because', price: 0
+      assert.deepInclude response(vars, {}, html('foo')), outcome: 'failure', reason: 'just because', price: 0
 
 
     it 'should revert to string search on non-HTML body', ->
       vars = outcome_search_term: 'bar'
       res = json(foo: 'bar')
       res.headers['Content-Type'] = 'text/html'
-      assert.deepEqual response(vars, {}, res).outcome, 'success'
+      assert.deepInclude response(vars, {}, res).outcome, 'success'
 
 
     it 'should use capture groups', ->
@@ -652,7 +652,7 @@ describe 'Response', ->
         outcome: 'success'
         number_records: '42'
         price: 0
-      assert.deepEqual response(vars, {}, html('<div>result: matched 42 records.</div>')), expected
+      assert.deepInclude response(vars, {}, html('<div>result: matched 42 records.</div>')), expected
 
     it 'should capture price when price_path is present', ->
       vars =
@@ -660,7 +660,7 @@ describe 'Response', ->
       expected = 
         outcome: 'success'
         price: "1.5"
-      assert.deepEqual response(vars, {}, html('<div class="cost">1.5</div>')), expected
+      assert.deepInclude response(vars, {}, html('<div class="cost">1.5</div>')), expected
 
   describe 'with xml body', ->
 
@@ -669,7 +669,7 @@ describe 'Response', ->
         outcome: 'success'
         foo: 'bar'
         price: 0
-      assert.deepEqual response({}, {}, xml(foo: 'bar')), expected
+      assert.deepInclude response({}, {}, xml(foo: 'bar')), expected
 
 
     it 'should default to failure per outcome on match', ->
@@ -677,7 +677,7 @@ describe 'Response', ->
         outcome: 'failure'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_on_match: 'failure', {}, xml(foo: 'bar')), expected
+      assert.deepInclude response(outcome_on_match: 'failure', {}, xml(foo: 'bar')), expected
 
 
     it 'should find search term with exact match', ->
@@ -685,7 +685,7 @@ describe 'Response', ->
         outcome: 'success'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(foo: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: 'foo', {}, xml(foo: 'bar')), expected
 
 
     it 'should find search term with exact match at path', ->
@@ -693,7 +693,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
     it 'should not find search term', ->
@@ -701,7 +701,7 @@ describe 'Response', ->
         outcome: 'failure'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'bip', {}, xml(foo: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: 'bip', {}, xml(foo: 'bar')), expected
 
 
     it 'should not find search term at path', ->
@@ -709,7 +709,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'bip', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: 'bip', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
     it 'should not find search term at different path', ->
@@ -719,7 +719,7 @@ describe 'Response', ->
         y:
           x: 'bip'
           baz: { bip: 'foo' }
-      assert.deepEqual response(outcome_search_term: 'bip', outcome_search_path: '/baz/bip/text()', {}, xml(y: { x: 'bip', baz: { bip: 'foo'}})), expected
+      assert.deepInclude response(outcome_search_term: 'bip', outcome_search_path: '/baz/bip/text()', {}, xml(y: { x: 'bip', baz: { bip: 'foo'}})), expected
 
 
     it 'should return failure on match per outcome on match', ->
@@ -727,7 +727,7 @@ describe 'Response', ->
         outcome: 'failure'
         foo: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, xml(foo: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_on_match: 'failure', {}, xml(foo: 'bar')), expected
 
 
     it 'should return failure on match per outcome on match at path', ->
@@ -735,7 +735,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_on_match: 'failure', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
     it 'should find search term with partial match', ->
@@ -743,7 +743,7 @@ describe 'Response', ->
         outcome: 'success'
         barfoobaz: 'bip'
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(barfoobaz: 'bip')), expected
+      assert.deepInclude response(outcome_search_term: 'foo', {}, xml(barfoobaz: 'bip')), expected
 
 
     it 'should find search term with partial match at path', ->
@@ -751,7 +751,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
 
 
     it 'should find search term with regex', ->
@@ -759,7 +759,7 @@ describe 'Response', ->
         outcome: 'success'
         barfoobaz: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, xml(barfoobaz: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', {}, xml(barfoobaz: 'bar')), expected
 
 
     it 'should find search term with regex at path', ->
@@ -767,7 +767,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
+      assert.deepInclude response(outcome_search_term: '[a-z]{3}foo[a-z]{3}', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
 
 
     it 'should find search term with regex including slashes', ->
@@ -775,7 +775,7 @@ describe 'Response', ->
         outcome: 'success'
         barfoobaz: 'bar'
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, xml(barfoobaz: 'bar')), expected
+      assert.deepInclude response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', {}, xml(barfoobaz: 'bar')), expected
 
 
     it 'should find search term with regex with slashes at path', ->
@@ -783,7 +783,7 @@ describe 'Response', ->
         outcome: 'success'
         baz: { bip: 'barfoobaz' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
+      assert.deepInclude response(outcome_search_term: '/[a-z]{3}foo[a-z]{3}/', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'barfoobaz' })), expected
 
 
     it 'should not error on invalid regex search term', ->
@@ -791,7 +791,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[/', {}, xml(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: '/[/', {}, xml(baz: { bip: 'foo'})), expected
 
 
     it 'should not error on invalid regex search term at path', ->
@@ -799,21 +799,21 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(outcome_search_term: '/[/', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
+      assert.deepInclude response(outcome_search_term: '/[/', outcome_search_path: '/baz/bip/text()', {}, xml(baz: { bip: 'foo'})), expected
 
 
     it 'should find search term with case insensitive match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
-      assert.deepEqual response(outcome_search_term: 'FOO', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepInclude response(outcome_search_term: 'FOO', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should find search term with case insensitive match at path', ->
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/baz', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
-      assert.deepEqual response(outcome_search_term: 'FOO', outcome_search_path: '/baz', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: '/baz', {}, xml(baz: 'FOO')), outcome: 'success', baz: 'FOO', price: 0
+      assert.deepInclude response(outcome_search_term: 'FOO', outcome_search_path: '/baz', {}, xml(baz: 'foo')), outcome: 'success', baz: 'foo', price: 0
 
 
     it 'should not find match', ->
-      assert.deepEqual response(outcome_search_term: 'foo', {}, xml(baz: 'bar')), outcome: 'failure', baz: 'bar', price: 0
+      assert.deepInclude response(outcome_search_term: 'foo', {}, xml(baz: 'bar')), outcome: 'failure', baz: 'bar', price: 0
 
 
     it 'should not find match at path', ->
@@ -821,7 +821,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'bar' }
         price: 0
-      assert.deepEqual response(outcome_search_term: 'foo', outcome_search_path: '/bip/text()', {}, xml(baz: { bip: 'bar' })), expected
+      assert.deepInclude response(outcome_search_term: 'foo', outcome_search_path: '/bip/text()', {}, xml(baz: { bip: 'bar' })), expected
 
 
     it 'should parse reason', ->
@@ -833,7 +833,7 @@ describe 'Response', ->
         reason: 'the reason text!'
         baz: { bip: 'the reason text!' }
         price: 0
-      assert.deepEqual response(vars, {}, xml(baz: { bip: 'the reason text!'})), expected
+      assert.deepInclude response(vars, {}, xml(baz: { bip: 'the reason text!'})), expected
 
 
     it 'should parse reason from CDATA', ->
@@ -867,7 +867,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: '' }
         price: 0
-      assert.deepEqual response(vars, {}, xml(baz: { bip: ''})), expected
+      assert.deepInclude response(vars, {}, xml(baz: { bip: ''})), expected
 
 
     it 'should discard whitespace reason', ->
@@ -878,7 +878,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: '     ' }
         price: 0
-      assert.deepEqual response(vars, {}, xml(baz: { bip: '     '})), expected
+      assert.deepInclude response(vars, {}, xml(baz: { bip: '     '})), expected
 
 
     it 'should parse multiple reasons', ->
@@ -890,7 +890,7 @@ describe 'Response', ->
         reason: 'another reason, the reason text!'
         baz: { bip: ['the reason text!', 'another reason'] }
         price: 0
-      assert.deepEqual response(vars, {}, xml(baz: { bip: ['the reason text!', 'another reason']})), expected
+      assert.deepInclude response(vars, {}, xml(baz: { bip: ['the reason text!', 'another reason']})), expected
 
 
     it 'should return default reason', ->
@@ -899,7 +899,7 @@ describe 'Response', ->
         reason: 'just because'
         baz: 'bip'
         price: 0
-      assert.deepEqual response(default_reason: 'just because', {}, xml(baz: 'bip')), expected
+      assert.deepInclude response(default_reason: 'just because', {}, xml(baz: 'bip')), expected
 
 
     it 'should fail to parse reason', ->
@@ -910,7 +910,7 @@ describe 'Response', ->
         outcome: 'failure'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(vars, {}, xml(baz: { bip: 'foo' })), expected
+      assert.deepInclude response(vars, {}, xml(baz: { bip: 'foo' })), expected
 
 
     it 'should use default reason on failure to parse reason', ->
@@ -923,7 +923,7 @@ describe 'Response', ->
         reason: 'just because'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(vars, {}, xml(baz: { bip: 'foo' })), expected
+      assert.deepInclude response(vars, {}, xml(baz: { bip: 'foo' })), expected
 
 
     it 'should use default reason on failure with invalid reason selector', ->
@@ -936,14 +936,14 @@ describe 'Response', ->
         reason: 'just because'
         baz: { bip: 'foo' }
         price: 0
-      assert.deepEqual response(vars, {}, xml(baz: { bip: 'foo' })), expected
+      assert.deepInclude response(vars, {}, xml(baz: { bip: 'foo' })), expected
 
 
     it 'should revert to string search on non-XML body', ->
       vars = outcome_search_term: 'bar'
       res = json(foo: { bar: 'baz'})
       res.headers['Content-Type'] = 'text/xml'
-      assert.deepEqual response(vars, {}, res), outcome: 'success', price: 0
+      assert.deepInclude response(vars, {}, res), outcome: 'success', price: 0
 
     it 'should capture price', ->
       vars =
@@ -953,7 +953,7 @@ describe 'Response', ->
         bar:
           cost: '1.5'
         outcome: 'success'
-      assert.deepEqual response(vars, {}, xml(bar: { cost: '1.5'})), expected
+      assert.deepInclude response(vars, {}, xml(bar: { cost: '1.5'})), expected
 
   describe 'HTTP status code', ->
 
@@ -1005,6 +1005,24 @@ describe 'Response', ->
         body: ''
       assert.deepEqual response({outcome_search_term: null, outcome_on_match: null}, {}, res).outcome, 'success'
 
+  describe 'header capture', ->
+
+    it 'should capture all headers', ->
+      res =
+        status: 200
+        headers:
+          'Content-Type': 'text/html'
+          'Content-Length': 0
+          'Access-Token': 1234
+        body: ''
+
+      expected =
+        'Content-Type': 'text/html'
+        'Content-Length': 0
+        'Access-Token': 1234
+      
+      assert.deepInclude response({}, {}, res), headers: expected
+
   describe 'cookie capture', ->
 
     before ->
@@ -1015,28 +1033,28 @@ describe 'Response', ->
           'Set-Cookie': @cookie
 
     it 'should not capture anything with no search-term', ->
-      assert.deepEqual response({}, {}, @res), outcome: 'success', price: 0
+      assert.deepInclude response({}, {}, @res), outcome: 'success', price: 0
 
 
     it 'should not capture anything when search-term does not match', ->
-      assert.deepEqual response(cookie_search_term: 'login_info', {}, @res), outcome: 'success', price: 0
+      assert.deepInclude response(cookie_search_term: 'login_info', {}, @res), outcome: 'success', price: 0
 
 
     it 'should not capture anything when regex search-term does not match', ->
-      assert.deepEqual response(cookie_search_term: 'domain=.x[0-9]{7}', {}, @res), outcome: 'success', price: 0
+      assert.deepInclude response(cookie_search_term: 'domain=.x[0-9]{7}', {}, @res), outcome: 'success', price: 0
 
 
     it 'should capture a cookie that matches string search-term', ->
-      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie, price: 0
+      assert.deepInclude response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie, price: 0
 
 
     it 'should capture a cookie regardless of search-term case', ->
-      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie, price: 0
-      assert.deepEqual response(cookie_search_term: 'SESSION_ID', {}, @res), outcome: 'success', cookie: @cookie, price: 0
+      assert.deepInclude response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: @cookie, price: 0
+      assert.deepInclude response(cookie_search_term: 'SESSION_ID', {}, @res), outcome: 'success', cookie: @cookie, price: 0
 
 
     it 'should capture a cookie that matches regex search-term', ->
-      assert.deepEqual response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: @cookie, price: 0
+      assert.deepInclude response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: @cookie, price: 0
 
 
     it 'should capture the first cookie (sorted lexicographically) when multiples match string search-term', ->
@@ -1047,7 +1065,7 @@ describe 'Response', ->
         cookie2
         cookie3
       ]
-      assert.deepEqual response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: cookie2, price: 0
+      assert.deepInclude response(cookie_search_term: 'session_id', {}, @res), outcome: 'success', cookie: cookie2, price: 0
 
     it 'should capture the first cookie (sorted lexicographically) when multiples match regex search-term', ->
       cookie2 = 'Session_id=123; path=/; domain=.fizzbuzz.com; expires=Sat, 01-Jan-2022 16:39:03 GMT; Max-Age=155520000; secure; httpOnly'
@@ -1057,7 +1075,7 @@ describe 'Response', ->
         cookie2
         cookie3
       ]
-      assert.deepEqual response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: cookie2, price: 0
+      assert.deepInclude response(cookie_search_term: 'session.*domain=.fizzbuzz', {}, @res), outcome: 'success', cookie: cookie2, price: 0
 
 
 xml = (obj) ->

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -201,6 +201,7 @@ response.variables = ->
     { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' }
     { name: 'cookie', type: 'string', description: 'The full cookie header string captured via match with \'cookie_search_term\'' }
     { name: 'price', type: 'number', description: 'The price of the lead' }
+    { name: 'headers.*', type: 'wildcard', description: 'All headers from the response' }
     { name: '*', type: 'wildcard' }
   ]
 

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -189,6 +189,7 @@ response = (vars, req, res) ->
   event.price = price || 0
   event.reason = reason if reason
   event.cookie = cookie if cookie
+  event.headers = res.headers
 
   # return the event
   event


### PR DESCRIPTION
You can read more about this ticket [here](https://app.clubhouse.io/active-prospect/story/4126/response-media-authentication).

As a quick gist of the ticket, the client needs to access the response headers in this integration. You will see a very small change in `response.coffee` that enables all headers to be passed back.

A side effect of changing the response variable is that it caused quite a few tests to fail (around 100). These tests were looking for deep equality between the response and a hardcoded json object, so the addition of headers caused them to fail. To solve this, I recommend changing `assert.deepEquals` to `assert.deepIncludes.` This ensures that the hardcoded json object and its values are all included and correct, but also allows extra key/value pairs (like `headers`) to exist without throwing the test.

**Lastly** It looks like this code is failing TravisCI because of one test - a timeout test that is unrelated to my changes. It looks like I don't have access to rerun the build, would someone mind rerunning it and seeing if it passes?

Thank you all, and please let me know if there are any questions!