### PR TITLE
Added basic username and password functionality on form, json, xml an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [2.18.4] - 2020-04-02
+### Added
+- JSON, XML, Form and Post integration now support basic username and password authorization
 ## [2.18.3] - 2020-03-27
 ### Fixed
 - Decaffeinated the integration

--- a/lib/form.js
+++ b/lib/form.js
@@ -7,6 +7,7 @@ const normalize = require('./normalize');
 const variables = require('./variables');
 const compact = require('./compact');
 const headers = require('./headers');
+const helpers = require('./helpers');
 
 
 
@@ -38,6 +39,10 @@ const request = function(vars) {
     'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'
   };
 
+  if (vars.basic_username && vars.basic_password) {
+    defaultHeaders['Authorization'] = helpers.encodeBasicAuth(vars.basic_username, vars.basic_password);
+  }
+
   return {
     url: vars.url,
     method: 'POST',
@@ -53,6 +58,8 @@ const request = function(vars) {
 
 request.variables = () => [
   { name: 'url', description: 'Server URL', type: 'string', required: true },
+  { name: 'basic_username', description: 'HTTP Basic Authentication user name', type: 'string', required: false },
+  { name: 'basic_password', description: 'HTTP Basic Authentication password', type: 'string', required: false },
   { name: 'encode_form_field_names', description: 'Whether form field names are URL-encoded (default: true)', type: 'boolean', required: false },
   { name: 'form_field.*', description: 'Form field name', type: 'wildcard', required: false }
 ].concat(variables);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,6 +17,10 @@ const ensureArray = function(val = []) {
   return val;
 };
 
+const encodeBasicAuth = function(username, password) {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`
+}
+
 const toRegex = function(expression) {
   expression = expression != null ? expression.trim().toLowerCase() : undefined;
   if (!expression) { return regexParser('.*'); }
@@ -42,6 +46,7 @@ const parameterize = function(param, body, extraParams) {
 module.exports = {
   inverseOutcome,
   ensureArray,
+  encodeBasicAuth,
   toRegex,
   parameterize
 }

--- a/lib/json.js
+++ b/lib/json.js
@@ -39,6 +39,10 @@ const request = function(vars) {
     'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'
   };
 
+  if (vars.basic_username && vars.basic_password) {
+    defaultHeaders['Authorization'] = helpers.encodeBasicAuth(vars.basic_username, vars.basic_password);
+  }
+
   if (vars.json_parameter) {
     body = helpers.parameterize(vars.json_parameter, body, vars.extra_parameter);
     defaultHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
@@ -63,6 +67,8 @@ const request = function(vars) {
 request.variables = () => [
   { name: 'url', description: 'Server URL', type: 'string', required: true },
   { name: 'method', description: 'HTTP method (POST, PUT, or DELETE)', type: 'string', required: true },
+  { name: 'basic_username', description: 'HTTP Basic Authentication user name', type: 'string', required: false },
+  { name: 'basic_password', description: 'HTTP Basic Authentication password', type: 'string', required: false },
   { name: 'json_property.*', description: 'JSON property in dot notation', type: 'wildcard', required: false },
   { name: 'json_parameter', description: 'To "stuff" the JSON into a parameter and send as Form URL encoded, specify the parameter name', type: 'string', required: false },
   { name: 'extra_parameter.*', description: 'Extra parameters to include in URL, only used when JSON Parameter is set', type: 'wildcard', required: false }

--- a/lib/query.js
+++ b/lib/query.js
@@ -7,6 +7,7 @@ const normalize = require('./normalize');
 const variables = require('./variables');
 const headers = require('./headers');
 const compact = require('./compact');
+const helpers = require('./helpers');
 
 
 //
@@ -24,11 +25,17 @@ const request = function(vars) {
   // URL encoded post body
   const query = querystring.encode(compact(content));
 
+  const defaultHeaders = {
+    'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'
+  }
+  if (vars.basic_username && vars.basic_password) {
+    defaultHeaders['Authorization'] = helpers.encodeBasicAuth(vars.basic_username, vars.basic_password);
+  }
+
   return {
     url: `${vars.url}?${query}`,
     method: 'GET',
-    headers: _.merge(headers(vars.header),
-      {'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'})
+    headers: _.merge(defaultHeaders, headers(vars.header))
   };
 };
 
@@ -39,7 +46,9 @@ const request = function(vars) {
 
 request.variables = () => [
   { name: 'url', description: 'Server URL', type: 'string', required: true },
-  { name: 'parameter.*', description: 'Parameter name', type: 'wildcard', required: false }
+  { name: 'parameter.*', description: 'Parameter name', type: 'wildcard', required: false },
+  { name: 'basic_username', description: 'HTTP Basic Authentication user name', type: 'string', required: false },
+  { name: 'basic_password', description: 'HTTP Basic Authentication password', type: 'string', required: false }
 ].concat(variables);
 
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -260,8 +260,7 @@ const toDoc = function(body, contentType) {
   try {
     let content = mimecontent(body || '', mimeType);
 
-    return (content != null) ? content : body;
-
+    return (content!= null) ? content : body;
   } catch (err) {
     // content parsing error, fall back to string body
     return body;

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -23,15 +23,21 @@ const request = function(vars) {
     contentType = 'application/x-www-form-urlencoded';
   }
 
+  defaultHeaders = {
+    'Content-Type': contentType,
+    'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'
+  }
+
+  if (vars.basic_username && vars.basic_password) {
+    defaultHeaders['Authorization'] = helpers.encodeBasicAuth(vars.basic_username, vars.basic_password);
+  }
+
+  defaultHeaders['Content-Length'] = Buffer.byteLength(body);
+
   return {
     url: vars.url,
     method: _.result(vars, 'method.toUpperCase') || 'POST',
-    headers: _.merge(headers(vars.header), {
-      'Content-Type': contentType,
-      'Content-Length': Buffer.byteLength(body),
-      'Accept': 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7,text/html;q=0.6,text/plain;q=0.5'
-    }
-    ),
+    headers: _.merge(defaultHeaders, headers(vars.header)),
     body
   };
 };
@@ -45,6 +51,8 @@ const request = function(vars) {
 request.variables = () => [
   { name: 'url', description: 'Server URL', type: 'string', required: true },
   { name: 'method', description: 'HTTP method (POST, PUT)', type: 'string', required: false },
+  { name: 'basic_username', description: 'HTTP Basic Authentication user name', type: 'string', required: false },
+  { name: 'basic_password', description: 'HTTP Basic Authentication password', type: 'string', required: false },
   { name: 'xml_path.*', description: 'XML path in dot notation', type: 'wildcard', required: false },
   { name: 'xml_parameter', description: 'To "stuff" the XML into a parameter and send as Form URL encoded, specify the parameter name', type: 'string', required: false },
   { name: 'extra_parameter.*', description: 'Extra parameters to include in URL, only used when XML Parameter is set', type: 'wildcard', required: false }

--- a/test/form-spec.js
+++ b/test/form-spec.js
@@ -44,6 +44,14 @@ describe('Outbound Form POST request', function() {
     assert.equal(integration.request(vars).body, 'fname=Mel&lname=Gibson');
   });
 
+  it('should accept and encode basic username and password', function() {
+    const vars = {
+      basic_username: 'test',
+      basic_password: 1234,
+    }
+    assert.equal(integration.request(vars).headers.Authorization, 'Basic dGVzdDoxMjM0')
+  });
+
 
   it('should send data as original UTF-8 when told to', function() {
     const vars = {

--- a/test/json-spec.js
+++ b/test/json-spec.js
@@ -229,6 +229,14 @@ describe('Outbound JSON request', function() {
     };
     assert.equal(integration.request(vars).body, '{"0":{"foo":{"bar":"baz"}},"bip":"bap"}');
   });
+
+  it('should accept and encode basic username and password', function() {
+    const vars = {
+      basic_username: 'test',
+      basic_password: 1234,
+    }
+    assert.equal(integration.request(vars).headers.Authorization, 'Basic dGVzdDoxMjM0')
+  })
 });
 
 

--- a/test/query-spec.js
+++ b/test/query-spec.js
@@ -40,6 +40,14 @@ describe('Outbound GET Query request', function() {
     assert.equal(integration.request(vars).url, 'http://foo.bar?fname=Mel&lname=Gibson');
   });
 
+  it('should accept and encode basic username and password', function() {
+    const vars = {
+      basic_username: 'test',
+      basic_password: 1234,
+    }
+    assert.equal(integration.request(vars).headers.Authorization, 'Basic dGVzdDoxMjM0')
+  });
+
 
   it('should send data as original UTF-8 when told to', function() {
     const vars = {

--- a/test/xml-spec.js
+++ b/test/xml-spec.js
@@ -59,6 +59,14 @@ describe('Outbound XML request', function() {
     );
   });
 
+  it('should accept and encode basic username and password', function() {
+    const vars = {
+      basic_username: 'test',
+      basic_password: 1234,
+    }
+    assert.equal(integration.request(vars).headers.Authorization, 'Basic dGVzdDoxMjM0')
+  })
+
   it('should send data as original UTF-8 when told to', function() {
     const vars = {
       send_ascii: types.boolean.parse('false'),


### PR DESCRIPTION
…d query integrations.

You can find the ticket for this PR [here](https://app.clubhouse.io/active-prospect/story/1301/add-support-for-basic-username-and-password-to-generic-integrations).

This PR does have some repeating code, which violates DRY. However, with such a small code addition I thought it was more readable, but I can change it if need be. Please let me know if there are any questions or needed changes. Thanks!