### PR TITLE
add lambda support for automated retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-lib
-node_modules
 .idea
 .DS_Store
-.vscode
 .nyc_output/
+.rip/pkg/leadconduit-custom.zip
+.vscode
 coverage/
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea
 .DS_Store
 .nyc_output/
-.rip/pkg/leadconduit-custom.zip
+.rip/pkg/*.zip
 .vscode
 coverage/
 node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,9 @@
-src
-spec
 Cakefile
 .idea
+lambda.js
+serverless.yml
+.github/
+test/
+.rip/
+coverage/
+.nyc_output/

--- a/.rip/handle.js
+++ b/.rip/handle.js
@@ -1,0 +1,260 @@
+
+// Lambda integration handle generator
+
+const _ = require('lodash');
+const dotaccess = require('dotaccess');
+const string = require('underscore.string');
+const path = require('path');
+const request = require('request');
+const fields = require('leadconduit-fields');
+
+const packages = {};
+const modules = {};
+const integrations = {};
+
+const maxTimeout = 360;
+const minTimeout = 1;
+
+function create (functionName) {
+  var api, i, id, integration, len, modulePath, name, paths, pkg, ref, ref1, results;
+  api = require(path.resolve('.'));
+  pkg = require(path.resolve('./package.json'));
+
+  // Remove UI
+  delete api.ui;
+
+  paths = findPaths(api);
+  name = pkg.name;
+  name = name.replace(/^@activeprospect\//, '');
+  module.exports[name] = api;
+  packages[name] = {
+    name: (ref = api.name) != null ? ref : _.capitalize(name.replace('leadconduit-', '')),
+    version: pkg.version,
+    description: pkg.description,
+    repo_url: pkg.repository.url,
+    paths: paths
+  };
+  results = {};
+  for (i = 0, len = paths.length; i < len; i++) {
+    modulePath = paths[i];
+    id = name + '.' + modulePath;
+    const shortName = id.split('.').pop();
+    if (functionName === shortName) {
+      integration = (ref1 = dotaccess.get(api, modulePath)) != null ? ref1 : api[modulePath];
+      return register(id, integration);
+    }
+  }
+  return results;
+}
+
+function register (id, integration) {
+  generateModule(id, integration);
+  generateHandle(integration);
+  generateTypes(id, integration);
+  generateAppendPrefix(id, integration);
+  integrations[id] = integration;
+  integration.name = id;
+  return integration;
+}
+
+// function deregister (id) {
+//   return delete integrations[id];
+// }
+
+// function lookup (moduleId) {
+//   return integrations[moduleId];
+// }
+
+function ensureTimeout (timeout) {
+  timeout = Number(timeout).valueOf();
+  if (!_.isFinite(timeout)) {
+    return maxTimeout;
+  }
+  if (timeout > maxTimeout) {
+    return maxTimeout;
+  }
+  if (timeout < minTimeout) {
+    return minTimeout;
+  }
+  return timeout;
+}
+
+function generateModule (id, integration) {
+  var friendlyName, modulePath, name, parts, ref, ref1, ref2, ref3, ref4, ref5, requestVariables, responseVariables, type;
+  parts = id.split(/\./);
+  name = parts.shift();
+  modulePath = parts.join('.');
+  friendlyName = integration.name || generateName(modulePath);
+  type = modulePath.match(/inbound/) ? 'inbound' : modulePath.match(/outbound/) ? 'outbound' : void 0;
+  requestVariables = (ref = (ref1 = integration != null ? typeof integration.requestVariables === 'function' ? integration.requestVariables() : void 0 : void 0) != null ? ref1 : (ref2 = integration.request) != null ? typeof ref2.variables === 'function' ? ref2.variables() : void 0 : void 0) != null ? ref : [];
+  responseVariables = (ref3 = (ref4 = integration != null ? typeof integration.responseVariables === 'function' ? integration.responseVariables() : void 0 : void 0) != null ? ref4 : (ref5 = integration.response) != null ? typeof ref5.variables === 'function' ? ref5.variables() : void 0 : void 0) != null ? ref3 : [];
+  if (type === 'outbound' && !_.find(requestVariables, {
+    name: 'timeout_seconds'
+  })) {
+    requestVariables.push({
+      name: 'timeout_seconds',
+      type: 'number',
+      description: 'Produce an "error" outcome if the server fails to respond within this number of seconds (default: 360)',
+      required: false
+    });
+  }
+  modules[id] = {
+    id: id,
+    type: type,
+    'package': packages[name],
+    path: modulePath,
+    name: friendlyName,
+    request_variables: requestVariables,
+    response_variables: responseVariables
+  };
+  return modules[id];
+}
+
+function generateHandle (outbound) {
+  if (!(typeof (outbound != null ? outbound.request : void 0) === 'function' && typeof (outbound != null ? outbound.response : void 0) === 'function')) {
+    return;
+  }
+  return outbound.handle != null ? outbound.handle : outbound.handle = function (vars, callback) {
+    var err, makeRequest, outboundReq;
+    try {
+      outboundReq = outbound.request(vars);
+    } catch (error) {
+      err = error;
+      return callback(err);
+    }
+    if (outboundReq.headers != null) {
+      outboundReq.headers['Content-Length'] = void 0;
+    }
+    makeRequest = function (options, cb) {
+      var ref, ref1, ref2, ref3;
+      options.url = (ref = options.url) != null ? ref.valueOf() : void 0;
+      if (!((ref1 = options.url) != null ? ref1.trim() : void 0)) {
+        return cb(new Error('request missing URL'));
+      }
+      if (!((ref2 = options.method) != null ? ref2.trim() : void 0)) {
+        return cb(new Error('request missing method'));
+      }
+      options.timeout = ensureTimeout((ref3 = options.timeout) != null ? ref3 : vars.timeout_seconds) * 1000;
+      try {
+        return request(options, cb);
+      } catch (error) {
+        err = error;
+        return cb(err);
+      }
+    };
+    return makeRequest(outboundReq, function (err, outboundRes, body) {
+      var event, ref, response;
+      if (err != null) {
+        return callback(err);
+      }
+      response = {
+        status: outboundRes.statusCode,
+        version: (ref = outboundRes.httpVersion) != null ? ref : '1.1',
+        headers: normalizeHeaders(outboundRes.headers),
+        body: body
+      };
+      try {
+        event = outbound.response(vars, outboundReq, response);
+      } catch (error) {
+        err = error;
+        return callback(err);
+      }
+      return callback(null, event);
+    });
+  };
+}
+
+function generateTypes (id, integration) {
+  var module;
+  module = modules[id];
+  if (integration.requestTypes == null) {
+    integration.requestTypes = getRequestTypes(module);
+  }
+  return integration.responseTypes != null ? integration.responseTypes : integration.responseTypes = getResponseTypes(module);
+}
+
+function getRequestTypes (module) {
+  return getTypes(module.request_variables);
+}
+
+function getResponseTypes (module) {
+  return getTypes(module.response_variables);
+}
+
+function getTypes (variables) {
+  var mapType;
+  mapType = function (types, v) {
+    var ref;
+    types[v.name] = (ref = v.type) != null ? ref : getDefaultType(v.name);
+    return types;
+  };
+  return (variables != null ? variables : []).reduce(mapType, {});
+}
+
+function getDefaultType (varName) {
+  var ref;
+  return (ref = fields.getType(varName)) != null ? ref : 'string';
+}
+
+function generateAppendPrefix (id, integration) {
+  var outcomeRegex, outcomeVar;
+  outcomeRegex = /\.?outcome$/;
+  outcomeVar = _.find(modules[id].response_variables, function (v) {
+    var ref;
+    return (ref = v.name) != null ? ref.match(outcomeRegex) : void 0;
+  });
+  if ((outcomeVar != null ? outcomeVar.name : void 0) != null) {
+    return integration.appendPrefix = outcomeVar.name.replace(outcomeRegex, '');
+  }
+}
+
+function normalizeHeaders (headers) {
+  var field, normalField, normalHeaders, normalizePart, value;
+  normalHeaders = {};
+  for (field in headers) {
+    value = headers[field];
+    normalizePart = function (part) {
+      return '' + (part[0].toUpperCase()) + (part.slice(1).toLowerCase());
+    };
+    normalField = field.split('-').map(normalizePart).join('-');
+    normalHeaders[normalField] = value;
+  }
+  return normalHeaders;
+}
+
+function generateName (modulePath) {
+  var name;
+  name = modulePath.replace(/(inbound|outbound)\./, '').replace(/_/g, ' ').split(/\s|\./).map(function (part) {
+    return string.capitalize(part);
+  });
+  return name.join(' ');
+}
+
+function findPaths (api, modulePath) {
+  var apiProperties, key, mod, paths;
+  if (modulePath == null) {
+    modulePath = '';
+  }
+  paths = [];
+  apiProperties = Object.keys(api);
+  if (apiProperties.indexOf('request') !== -1 || apiProperties.indexOf('handle') !== -1) {
+    paths.push(modulePath);
+  } else {
+    for (key in api) {
+      mod = api[key];
+      if (key === 'name') {
+        continue;
+      }
+      paths = paths.concat(findPaths(mod, [modulePath, key].filter(empty).join('.')));
+    }
+  }
+  return paths;
+}
+
+function empty (str) {
+  return !!(str != null ? str.trim() : void 0);
+}
+
+module.exports = {
+  create
+};

--- a/.rip/pkg/cloudformation-template-create-stack.json
+++ b/.rip/pkg/cloudformation-template-create-stack.json
@@ -1,0 +1,82 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "The AWS CloudFormation template for this Serverless application",
+  "Resources": {
+    "ServerlessDeploymentBucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentBucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "ServerlessDeploymentBucket"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      },
+                      "/*"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ServerlessDeploymentBucketName": {
+      "Value": {
+        "Ref": "ServerlessDeploymentBucket"
+      }
+    }
+  }
+}

--- a/.rip/pkg/cloudformation-template-update-stack.json
+++ b/.rip/pkg/cloudformation-template-update-stack.json
@@ -209,7 +209,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.form",
         "Runtime": "nodejs12.x",
@@ -239,7 +239,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.json",
         "Runtime": "nodejs12.x",
@@ -269,7 +269,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.query",
         "Runtime": "nodejs12.x",
@@ -299,7 +299,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.xml",
         "Runtime": "nodejs12.x",
@@ -329,7 +329,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.soap",
         "Runtime": "nodejs12.x",
@@ -352,54 +352,54 @@
         "SoapLogGroup"
       ]
     },
-    "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4": {
+    "FormLambdaVersionwM0qvUwpOR264cYCKphWbluEHtWn8c9cethif5Ledg": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "FormLambdaFunction"
         },
-        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+        "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
       }
     },
-    "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ": {
+    "JsonLambdaVersionUEbjgyPdvh3LGCDLzFyBVDgG5VhJtpB7eWqemQwk4t8": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JsonLambdaFunction"
         },
-        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+        "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
       }
     },
-    "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "XmlLambdaFunction"
-        },
-        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
-      }
-    },
-    "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU": {
+    "QueryLambdaVersionxP3m2e3i9BzFhxWTHRqhnBImivguUPyO9bLH6OZQURo": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "QueryLambdaFunction"
         },
-        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+        "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
       }
     },
-    "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU": {
+    "XmlLambdaVersionPwBgT7opt01xCXR9raf0ZYCtUVp9ZBbcufFLPYFMm0s": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "XmlLambdaFunction"
+        },
+        "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
+      }
+    },
+    "SoapLambdaVersion9nTzv2dXKCD0EHe6pbfwjVgWS7wwhhSZKxhk8zvXS8": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "SoapLambdaFunction"
         },
-        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+        "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
       }
     },
     "ApiGatewayRestApi": {
@@ -704,7 +704,7 @@
         "MethodResponses": []
       }
     },
-    "ApiGatewayDeployment1610491791277": {
+    "ApiGatewayDeployment1610675343000": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
@@ -915,31 +915,31 @@
     "FormLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4"
+        "Ref": "FormLambdaVersionwM0qvUwpOR264cYCKphWbluEHtWn8c9cethif5Ledg"
       }
     },
     "JsonLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ"
-      }
-    },
-    "XmlLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo"
+        "Ref": "JsonLambdaVersionUEbjgyPdvh3LGCDLzFyBVDgG5VhJtpB7eWqemQwk4t8"
       }
     },
     "QueryLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU"
+        "Ref": "QueryLambdaVersionxP3m2e3i9BzFhxWTHRqhnBImivguUPyO9bLH6OZQURo"
+      }
+    },
+    "XmlLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "XmlLambdaVersionPwBgT7opt01xCXR9raf0ZYCtUVp9ZBbcufFLPYFMm0s"
       }
     },
     "SoapLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU"
+        "Ref": "SoapLambdaVersion9nTzv2dXKCD0EHe6pbfwjVgWS7wwhhSZKxhk8zvXS8"
       }
     },
     "ServiceEndpoint": {

--- a/.rip/pkg/cloudformation-template-update-stack.json
+++ b/.rip/pkg/cloudformation-template-update-stack.json
@@ -1,0 +1,969 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "The AWS CloudFormation template for this Serverless application",
+  "Resources": {
+    "ServerlessDeploymentBucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentBucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "ServerlessDeploymentBucket"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      },
+                      "/*"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "FormLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-form"
+      }
+    },
+    "JsonLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-json"
+      }
+    },
+    "QueryLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-query"
+      }
+    },
+    "XmlLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-xml"
+      }
+    },
+    "SoapLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-soap"
+      }
+    },
+    "IamRoleLambdaExecution": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": {
+              "Fn::Join": [
+                "-",
+                [
+                  "leadconduit-custom",
+                  "dev",
+                  "lambda"
+                ]
+              ]
+            },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:CreateLogGroup"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-form:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-json:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-query:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-xml:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-soap:*"
+                    }
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-form:*:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-json:*:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-query:*:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-xml:*:*"
+                    },
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-soap:*:*"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "Path": "/",
+        "RoleName": {
+          "Fn::Join": [
+            "-",
+            [
+              "leadconduit-custom",
+              "dev",
+              {
+                "Ref": "AWS::Region"
+              },
+              "lambdaRole"
+            ]
+          ]
+        }
+      }
+    },
+    "FormLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+        },
+        "Handler": "lambda.form",
+        "Runtime": "nodejs12.x",
+        "FunctionName": "leadconduit-custom-outbound-form",
+        "MemorySize": 128,
+        "Timeout": 30,
+        "Environment": {
+          "Variables": {
+            "NODE_ENV": "development"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "FormLogGroup"
+      ]
+    },
+    "JsonLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+        },
+        "Handler": "lambda.json",
+        "Runtime": "nodejs12.x",
+        "FunctionName": "leadconduit-custom-outbound-json",
+        "MemorySize": 128,
+        "Timeout": 30,
+        "Environment": {
+          "Variables": {
+            "NODE_ENV": "development"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "JsonLogGroup"
+      ]
+    },
+    "QueryLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+        },
+        "Handler": "lambda.query",
+        "Runtime": "nodejs12.x",
+        "FunctionName": "leadconduit-custom-outbound-query",
+        "MemorySize": 128,
+        "Timeout": 30,
+        "Environment": {
+          "Variables": {
+            "NODE_ENV": "development"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "QueryLogGroup"
+      ]
+    },
+    "XmlLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+        },
+        "Handler": "lambda.xml",
+        "Runtime": "nodejs12.x",
+        "FunctionName": "leadconduit-custom-outbound-xml",
+        "MemorySize": 128,
+        "Timeout": 30,
+        "Environment": {
+          "Variables": {
+            "NODE_ENV": "development"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "XmlLogGroup"
+      ]
+    },
+    "SoapLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+        },
+        "Handler": "lambda.soap",
+        "Runtime": "nodejs12.x",
+        "FunctionName": "leadconduit-custom-outbound-soap",
+        "MemorySize": 128,
+        "Timeout": 30,
+        "Environment": {
+          "Variables": {
+            "NODE_ENV": "development"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "SoapLogGroup"
+      ]
+    },
+    "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "FormLambdaFunction"
+        },
+        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+      }
+    },
+    "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "JsonLambdaFunction"
+        },
+        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+      }
+    },
+    "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "QueryLambdaFunction"
+        },
+        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+      }
+    },
+    "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "XmlLambdaFunction"
+        },
+        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+      }
+    },
+    "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SoapLambdaFunction"
+        },
+        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+      }
+    },
+    "ApiGatewayRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "dev-leadconduit-custom",
+        "EndpointConfiguration": {
+          "Types": [
+            "EDGE"
+          ]
+        },
+        "Policy": ""
+      }
+    },
+    "ApiGatewayResourceForm": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGatewayRestApi",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "form",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        }
+      }
+    },
+    "ApiGatewayResourceJson": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGatewayRestApi",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "json",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        }
+      }
+    },
+    "ApiGatewayResourceQuery": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGatewayRestApi",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "query",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        }
+      }
+    },
+    "ApiGatewayResourceXml": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGatewayRestApi",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "xml",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        }
+      }
+    },
+    "ApiGatewayResourceSoap": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGatewayRestApi",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "soap",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        }
+      }
+    },
+    "ApiGatewayMethodFormPost": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "RequestParameters": {},
+        "ResourceId": {
+          "Ref": "ApiGatewayResourceForm"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "FormLambdaFunction",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": []
+      }
+    },
+    "ApiGatewayMethodJsonPost": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "RequestParameters": {},
+        "ResourceId": {
+          "Ref": "ApiGatewayResourceJson"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "JsonLambdaFunction",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": []
+      }
+    },
+    "ApiGatewayMethodQueryPost": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "RequestParameters": {},
+        "ResourceId": {
+          "Ref": "ApiGatewayResourceQuery"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "QueryLambdaFunction",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": []
+      }
+    },
+    "ApiGatewayMethodXmlPost": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "RequestParameters": {},
+        "ResourceId": {
+          "Ref": "ApiGatewayResourceXml"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "XmlLambdaFunction",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": []
+      }
+    },
+    "ApiGatewayMethodSoapPost": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "RequestParameters": {},
+        "ResourceId": {
+          "Ref": "ApiGatewayResourceSoap"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "SoapLambdaFunction",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": []
+      }
+    },
+    "ApiGatewayDeployment1610314621121": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "StageName": "dev"
+      },
+      "DependsOn": [
+        "ApiGatewayMethodFormPost",
+        "ApiGatewayMethodJsonPost",
+        "ApiGatewayMethodQueryPost",
+        "ApiGatewayMethodXmlPost",
+        "ApiGatewayMethodSoapPost"
+      ]
+    },
+    "FormLambdaPermissionApiGateway": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "FormLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      }
+    },
+    "JsonLambdaPermissionApiGateway": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "JsonLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      }
+    },
+    "QueryLambdaPermissionApiGateway": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "QueryLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      }
+    },
+    "XmlLambdaPermissionApiGateway": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "XmlLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      }
+    },
+    "SoapLambdaPermissionApiGateway": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SoapLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ServerlessDeploymentBucketName": {
+      "Value": {
+        "Ref": "ServerlessDeploymentBucket"
+      }
+    },
+    "FormLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0"
+      }
+    },
+    "JsonLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY"
+      }
+    },
+    "QueryLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8"
+      }
+    },
+    "XmlLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY"
+      }
+    },
+    "SoapLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw"
+      }
+    },
+    "ServiceEndpoint": {
+      "Description": "URL of the service endpoint",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "ApiGatewayRestApi"
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix"
+            },
+            "/dev"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/.rip/pkg/cloudformation-template-update-stack.json
+++ b/.rip/pkg/cloudformation-template-update-stack.json
@@ -209,7 +209,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.form",
         "Runtime": "nodejs12.x",
@@ -239,7 +239,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.json",
         "Runtime": "nodejs12.x",
@@ -269,7 +269,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.query",
         "Runtime": "nodejs12.x",
@@ -299,7 +299,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.xml",
         "Runtime": "nodejs12.x",
@@ -329,7 +329,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+          "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
         },
         "Handler": "lambda.soap",
         "Runtime": "nodejs12.x",
@@ -352,54 +352,54 @@
         "SoapLogGroup"
       ]
     },
-    "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0": {
+    "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "FormLambdaFunction"
         },
-        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
       }
     },
-    "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY": {
+    "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JsonLambdaFunction"
         },
-        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
       }
     },
-    "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "QueryLambdaFunction"
-        },
-        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
-      }
-    },
-    "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY": {
+    "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "XmlLambdaFunction"
         },
-        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
       }
     },
-    "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw": {
+    "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "QueryLambdaFunction"
+        },
+        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+      }
+    },
+    "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "SoapLambdaFunction"
         },
-        "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+        "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
       }
     },
     "ApiGatewayRestApi": {
@@ -704,7 +704,7 @@
         "MethodResponses": []
       }
     },
-    "ApiGatewayDeployment1610314621121": {
+    "ApiGatewayDeployment1610491791277": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
@@ -915,31 +915,31 @@
     "FormLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0"
+        "Ref": "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4"
       }
     },
     "JsonLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY"
-      }
-    },
-    "QueryLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8"
+        "Ref": "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ"
       }
     },
     "XmlLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY"
+        "Ref": "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo"
+      }
+    },
+    "QueryLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU"
       }
     },
     "SoapLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw"
+        "Ref": "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU"
       }
     },
     "ServiceEndpoint": {

--- a/.rip/pkg/serverless-state.json
+++ b/.rip/pkg/serverless-state.json
@@ -227,7 +227,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.form",
               "Runtime": "nodejs12.x",
@@ -257,7 +257,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.json",
               "Runtime": "nodejs12.x",
@@ -287,7 +287,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.query",
               "Runtime": "nodejs12.x",
@@ -317,7 +317,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.xml",
               "Runtime": "nodejs12.x",
@@ -347,7 +347,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.soap",
               "Runtime": "nodejs12.x",
@@ -370,54 +370,54 @@
               "SoapLogGroup"
             ]
           },
-          "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0": {
+          "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "FormLambdaFunction"
               },
-              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
             }
           },
-          "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY": {
+          "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "JsonLambdaFunction"
               },
-              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
             }
           },
-          "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8": {
-            "Type": "AWS::Lambda::Version",
-            "DeletionPolicy": "Retain",
-            "Properties": {
-              "FunctionName": {
-                "Ref": "QueryLambdaFunction"
-              },
-              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
-            }
-          },
-          "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY": {
+          "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "XmlLambdaFunction"
               },
-              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
             }
           },
-          "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw": {
+          "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU": {
+            "Type": "AWS::Lambda::Version",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+              "FunctionName": {
+                "Ref": "QueryLambdaFunction"
+              },
+              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+            }
+          },
+          "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "SoapLambdaFunction"
               },
-              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
             }
           },
           "ApiGatewayRestApi": {
@@ -722,7 +722,7 @@
               "MethodResponses": []
             }
           },
-          "ApiGatewayDeployment1610314621121": {
+          "ApiGatewayDeployment1610491791277": {
             "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
               "RestApiId": {
@@ -933,31 +933,31 @@
           "FormLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0"
+              "Ref": "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4"
             }
           },
           "JsonLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY"
-            }
-          },
-          "QueryLambdaFunctionQualifiedArn": {
-            "Description": "Current Lambda function version",
-            "Value": {
-              "Ref": "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8"
+              "Ref": "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ"
             }
           },
           "XmlLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY"
+              "Ref": "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo"
+            }
+          },
+          "QueryLambdaFunctionQualifiedArn": {
+            "Description": "Current Lambda function version",
+            "Value": {
+              "Ref": "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU"
             }
           },
           "SoapLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw"
+              "Ref": "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU"
             }
           },
           "ServiceEndpoint": {
@@ -1088,7 +1088,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0"
+        "versionLogicalId": "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4"
       },
       "json": {
         "handler": "lambda.json",
@@ -1107,7 +1107,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY"
+        "versionLogicalId": "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ"
       },
       "query": {
         "handler": "lambda.query",
@@ -1126,7 +1126,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8"
+        "versionLogicalId": "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU"
       },
       "xml": {
         "handler": "lambda.xml",
@@ -1145,7 +1145,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY"
+        "versionLogicalId": "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo"
       },
       "soap": {
         "handler": "lambda.soap",
@@ -1164,7 +1164,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw"
+        "versionLogicalId": "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU"
       }
     },
     "configValidationMode": "warn",
@@ -1203,7 +1203,7 @@
           "README.md"
         ],
         "artifact": "/Users/michaelbetts/repos/leadconduit-integration-custom/.serverless/leadconduit-custom.zip",
-        "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z"
+        "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z"
       },
       "functions": {
         "$ref": "$[\"service\"][\"functions\"]"
@@ -1213,7 +1213,7 @@
     "artifact": "/Users/michaelbetts/repos/leadconduit-integration-custom/.serverless/leadconduit-custom.zip"
   },
   "package": {
-    "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z",
+    "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z",
     "artifact": "leadconduit-custom.zip"
   }
 }

--- a/.rip/pkg/serverless-state.json
+++ b/.rip/pkg/serverless-state.json
@@ -227,7 +227,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.form",
               "Runtime": "nodejs12.x",
@@ -257,7 +257,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.json",
               "Runtime": "nodejs12.x",
@@ -287,7 +287,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.query",
               "Runtime": "nodejs12.x",
@@ -317,7 +317,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.xml",
               "Runtime": "nodejs12.x",
@@ -347,7 +347,7 @@
                 "S3Bucket": {
                   "Ref": "ServerlessDeploymentBucket"
                 },
-                "S3Key": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z/leadconduit-custom.zip"
+                "S3Key": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z/leadconduit-custom.zip"
               },
               "Handler": "lambda.soap",
               "Runtime": "nodejs12.x",
@@ -370,54 +370,54 @@
               "SoapLogGroup"
             ]
           },
-          "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4": {
+          "FormLambdaVersionwM0qvUwpOR264cYCKphWbluEHtWn8c9cethif5Ledg": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "FormLambdaFunction"
               },
-              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+              "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
             }
           },
-          "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ": {
+          "JsonLambdaVersionUEbjgyPdvh3LGCDLzFyBVDgG5VhJtpB7eWqemQwk4t8": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "JsonLambdaFunction"
               },
-              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+              "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
             }
           },
-          "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo": {
-            "Type": "AWS::Lambda::Version",
-            "DeletionPolicy": "Retain",
-            "Properties": {
-              "FunctionName": {
-                "Ref": "XmlLambdaFunction"
-              },
-              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
-            }
-          },
-          "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU": {
+          "QueryLambdaVersionxP3m2e3i9BzFhxWTHRqhnBImivguUPyO9bLH6OZQURo": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "QueryLambdaFunction"
               },
-              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+              "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
             }
           },
-          "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU": {
+          "XmlLambdaVersionPwBgT7opt01xCXR9raf0ZYCtUVp9ZBbcufFLPYFMm0s": {
+            "Type": "AWS::Lambda::Version",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+              "FunctionName": {
+                "Ref": "XmlLambdaFunction"
+              },
+              "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
+            }
+          },
+          "SoapLambdaVersion9nTzv2dXKCD0EHe6pbfwjVgWS7wwhhSZKxhk8zvXS8": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "SoapLambdaFunction"
               },
-              "CodeSha256": "fDwYtU0yRAKD4kYWVe+I4q1qErdnmQK8yaJVxBKBUOY="
+              "CodeSha256": "08vI3FDZ7+HjhKf8qPjxt8O0kePDDToCdsA3mPZbD5Y="
             }
           },
           "ApiGatewayRestApi": {
@@ -722,7 +722,7 @@
               "MethodResponses": []
             }
           },
-          "ApiGatewayDeployment1610491791277": {
+          "ApiGatewayDeployment1610675343000": {
             "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
               "RestApiId": {
@@ -933,31 +933,31 @@
           "FormLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4"
+              "Ref": "FormLambdaVersionwM0qvUwpOR264cYCKphWbluEHtWn8c9cethif5Ledg"
             }
           },
           "JsonLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ"
-            }
-          },
-          "XmlLambdaFunctionQualifiedArn": {
-            "Description": "Current Lambda function version",
-            "Value": {
-              "Ref": "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo"
+              "Ref": "JsonLambdaVersionUEbjgyPdvh3LGCDLzFyBVDgG5VhJtpB7eWqemQwk4t8"
             }
           },
           "QueryLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU"
+              "Ref": "QueryLambdaVersionxP3m2e3i9BzFhxWTHRqhnBImivguUPyO9bLH6OZQURo"
+            }
+          },
+          "XmlLambdaFunctionQualifiedArn": {
+            "Description": "Current Lambda function version",
+            "Value": {
+              "Ref": "XmlLambdaVersionPwBgT7opt01xCXR9raf0ZYCtUVp9ZBbcufFLPYFMm0s"
             }
           },
           "SoapLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU"
+              "Ref": "SoapLambdaVersion9nTzv2dXKCD0EHe6pbfwjVgWS7wwhhSZKxhk8zvXS8"
             }
           },
           "ServiceEndpoint": {
@@ -1088,7 +1088,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "FormLambdaVersionNcxIEUqpoEr1JviBMF3ikSMWFNRWEwQy3pyfGnMj7Y4"
+        "versionLogicalId": "FormLambdaVersionwM0qvUwpOR264cYCKphWbluEHtWn8c9cethif5Ledg"
       },
       "json": {
         "handler": "lambda.json",
@@ -1107,7 +1107,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "JsonLambdaVersion7sjKqym0AnG0z6OfR2GOLvG6mA9fV53eJzmYXsX5uQ"
+        "versionLogicalId": "JsonLambdaVersionUEbjgyPdvh3LGCDLzFyBVDgG5VhJtpB7eWqemQwk4t8"
       },
       "query": {
         "handler": "lambda.query",
@@ -1126,7 +1126,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "QueryLambdaVersionL4a5ZldJIZhaegIR7JbLPyMfkOBlTe35W79CKOU"
+        "versionLogicalId": "QueryLambdaVersionxP3m2e3i9BzFhxWTHRqhnBImivguUPyO9bLH6OZQURo"
       },
       "xml": {
         "handler": "lambda.xml",
@@ -1145,7 +1145,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "XmlLambdaVersionpIEckpuSUhrVVBcQuS3fhszh8nA8jfQ6SmzS4UMMo"
+        "versionLogicalId": "XmlLambdaVersionPwBgT7opt01xCXR9raf0ZYCtUVp9ZBbcufFLPYFMm0s"
       },
       "soap": {
         "handler": "lambda.soap",
@@ -1164,7 +1164,7 @@
         "timeout": 30,
         "runtime": "nodejs12.x",
         "vpc": {},
-        "versionLogicalId": "SoapLambdaVersionKwckJYGNEGdDsANbaWWjraArThDhUWi8kaoMatoU"
+        "versionLogicalId": "SoapLambdaVersion9nTzv2dXKCD0EHe6pbfwjVgWS7wwhhSZKxhk8zvXS8"
       }
     },
     "configValidationMode": "warn",
@@ -1203,7 +1203,7 @@
           "README.md"
         ],
         "artifact": "/Users/michaelbetts/repos/leadconduit-integration-custom/.serverless/leadconduit-custom.zip",
-        "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z"
+        "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z"
       },
       "functions": {
         "$ref": "$[\"service\"][\"functions\"]"
@@ -1213,7 +1213,7 @@
     "artifact": "/Users/michaelbetts/repos/leadconduit-integration-custom/.serverless/leadconduit-custom.zip"
   },
   "package": {
-    "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610491803201-2021-01-12T22:50:03.201Z",
+    "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610675350765-2021-01-15T01:49:10.765Z",
     "artifact": "leadconduit-custom.zip"
   }
 }

--- a/.rip/pkg/serverless-state.json
+++ b/.rip/pkg/serverless-state.json
@@ -1,0 +1,1219 @@
+{
+  "service": {
+    "service": "leadconduit-custom",
+    "serviceObject": {
+      "name": "leadconduit-custom"
+    },
+    "provider": {
+      "name": "aws",
+      "runtime": "nodejs12.x",
+      "memorySize": 128,
+      "timeout": 30,
+      "environment": {
+        "NODE_ENV": "development"
+      },
+      "stage": "dev",
+      "variableSyntax": "\\${([^{}:]+?(?:\\(|:)(?:[^:{}][^{}]*?)?)}",
+      "region": "us-east-1",
+      "versionFunctions": true,
+      "compiledCloudFormationTemplate": {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "The AWS CloudFormation template for this Serverless application",
+        "Resources": {
+          "ServerlessDeploymentBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+              "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                  {
+                    "ServerSideEncryptionByDefault": {
+                      "SSEAlgorithm": "AES256"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ServerlessDeploymentBucketPolicy": {
+            "Type": "AWS::S3::BucketPolicy",
+            "Properties": {
+              "Bucket": {
+                "Ref": "ServerlessDeploymentBucket"
+              },
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": "s3:*",
+                    "Effect": "Deny",
+                    "Principal": "*",
+                    "Resource": [
+                      {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:",
+                            {
+                              "Ref": "AWS::Partition"
+                            },
+                            ":s3:::",
+                            {
+                              "Ref": "ServerlessDeploymentBucket"
+                            },
+                            "/*"
+                          ]
+                        ]
+                      },
+                      {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:",
+                            {
+                              "Ref": "AWS::Partition"
+                            },
+                            ":s3:::",
+                            {
+                              "Ref": "ServerlessDeploymentBucket"
+                            }
+                          ]
+                        ]
+                      }
+                    ],
+                    "Condition": {
+                      "Bool": {
+                        "aws:SecureTransport": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "FormLogGroup": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+              "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-form"
+            }
+          },
+          "JsonLogGroup": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+              "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-json"
+            }
+          },
+          "QueryLogGroup": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+              "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-query"
+            }
+          },
+          "XmlLogGroup": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+              "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-xml"
+            }
+          },
+          "SoapLogGroup": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+              "LogGroupName": "/aws/lambda/leadconduit-custom-outbound-soap"
+            }
+          },
+          "IamRoleLambdaExecution": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+              "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Service": [
+                        "lambda.amazonaws.com"
+                      ]
+                    },
+                    "Action": [
+                      "sts:AssumeRole"
+                    ]
+                  }
+                ]
+              },
+              "Policies": [
+                {
+                  "PolicyName": {
+                    "Fn::Join": [
+                      "-",
+                      [
+                        "leadconduit-custom",
+                        "dev",
+                        "lambda"
+                      ]
+                    ]
+                  },
+                  "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                      {
+                        "Effect": "Allow",
+                        "Action": [
+                          "logs:CreateLogStream",
+                          "logs:CreateLogGroup"
+                        ],
+                        "Resource": [
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-form:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-json:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-query:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-xml:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-soap:*"
+                          }
+                        ]
+                      },
+                      {
+                        "Effect": "Allow",
+                        "Action": [
+                          "logs:PutLogEvents"
+                        ],
+                        "Resource": [
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-form:*:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-json:*:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-query:*:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-xml:*:*"
+                          },
+                          {
+                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/leadconduit-custom-outbound-soap:*:*"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "Path": "/",
+              "RoleName": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    "leadconduit-custom",
+                    "dev",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "lambdaRole"
+                  ]
+                ]
+              }
+            }
+          },
+          "FormLambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+              "Code": {
+                "S3Bucket": {
+                  "Ref": "ServerlessDeploymentBucket"
+                },
+                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+              },
+              "Handler": "lambda.form",
+              "Runtime": "nodejs12.x",
+              "FunctionName": "leadconduit-custom-outbound-form",
+              "MemorySize": 128,
+              "Timeout": 30,
+              "Environment": {
+                "Variables": {
+                  "NODE_ENV": "development"
+                }
+              },
+              "Role": {
+                "Fn::GetAtt": [
+                  "IamRoleLambdaExecution",
+                  "Arn"
+                ]
+              }
+            },
+            "DependsOn": [
+              "FormLogGroup"
+            ]
+          },
+          "JsonLambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+              "Code": {
+                "S3Bucket": {
+                  "Ref": "ServerlessDeploymentBucket"
+                },
+                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+              },
+              "Handler": "lambda.json",
+              "Runtime": "nodejs12.x",
+              "FunctionName": "leadconduit-custom-outbound-json",
+              "MemorySize": 128,
+              "Timeout": 30,
+              "Environment": {
+                "Variables": {
+                  "NODE_ENV": "development"
+                }
+              },
+              "Role": {
+                "Fn::GetAtt": [
+                  "IamRoleLambdaExecution",
+                  "Arn"
+                ]
+              }
+            },
+            "DependsOn": [
+              "JsonLogGroup"
+            ]
+          },
+          "QueryLambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+              "Code": {
+                "S3Bucket": {
+                  "Ref": "ServerlessDeploymentBucket"
+                },
+                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+              },
+              "Handler": "lambda.query",
+              "Runtime": "nodejs12.x",
+              "FunctionName": "leadconduit-custom-outbound-query",
+              "MemorySize": 128,
+              "Timeout": 30,
+              "Environment": {
+                "Variables": {
+                  "NODE_ENV": "development"
+                }
+              },
+              "Role": {
+                "Fn::GetAtt": [
+                  "IamRoleLambdaExecution",
+                  "Arn"
+                ]
+              }
+            },
+            "DependsOn": [
+              "QueryLogGroup"
+            ]
+          },
+          "XmlLambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+              "Code": {
+                "S3Bucket": {
+                  "Ref": "ServerlessDeploymentBucket"
+                },
+                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+              },
+              "Handler": "lambda.xml",
+              "Runtime": "nodejs12.x",
+              "FunctionName": "leadconduit-custom-outbound-xml",
+              "MemorySize": 128,
+              "Timeout": 30,
+              "Environment": {
+                "Variables": {
+                  "NODE_ENV": "development"
+                }
+              },
+              "Role": {
+                "Fn::GetAtt": [
+                  "IamRoleLambdaExecution",
+                  "Arn"
+                ]
+              }
+            },
+            "DependsOn": [
+              "XmlLogGroup"
+            ]
+          },
+          "SoapLambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+              "Code": {
+                "S3Bucket": {
+                  "Ref": "ServerlessDeploymentBucket"
+                },
+                "S3Key": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z/leadconduit-custom.zip"
+              },
+              "Handler": "lambda.soap",
+              "Runtime": "nodejs12.x",
+              "FunctionName": "leadconduit-custom-outbound-soap",
+              "MemorySize": 128,
+              "Timeout": 30,
+              "Environment": {
+                "Variables": {
+                  "NODE_ENV": "development"
+                }
+              },
+              "Role": {
+                "Fn::GetAtt": [
+                  "IamRoleLambdaExecution",
+                  "Arn"
+                ]
+              }
+            },
+            "DependsOn": [
+              "SoapLogGroup"
+            ]
+          },
+          "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0": {
+            "Type": "AWS::Lambda::Version",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+              "FunctionName": {
+                "Ref": "FormLambdaFunction"
+              },
+              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+            }
+          },
+          "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY": {
+            "Type": "AWS::Lambda::Version",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+              "FunctionName": {
+                "Ref": "JsonLambdaFunction"
+              },
+              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+            }
+          },
+          "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8": {
+            "Type": "AWS::Lambda::Version",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+              "FunctionName": {
+                "Ref": "QueryLambdaFunction"
+              },
+              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+            }
+          },
+          "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY": {
+            "Type": "AWS::Lambda::Version",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+              "FunctionName": {
+                "Ref": "XmlLambdaFunction"
+              },
+              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+            }
+          },
+          "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw": {
+            "Type": "AWS::Lambda::Version",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+              "FunctionName": {
+                "Ref": "SoapLambdaFunction"
+              },
+              "CodeSha256": "uZIFqcUeh6sIF3j0hnE+cHQx24M5ViNg3MNJYVZIe+A="
+            }
+          },
+          "ApiGatewayRestApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+              "Name": "dev-leadconduit-custom",
+              "EndpointConfiguration": {
+                "Types": [
+                  "EDGE"
+                ]
+              },
+              "Policy": ""
+            }
+          },
+          "ApiGatewayResourceForm": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Properties": {
+              "ParentId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayRestApi",
+                  "RootResourceId"
+                ]
+              },
+              "PathPart": "form",
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              }
+            }
+          },
+          "ApiGatewayResourceJson": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Properties": {
+              "ParentId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayRestApi",
+                  "RootResourceId"
+                ]
+              },
+              "PathPart": "json",
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              }
+            }
+          },
+          "ApiGatewayResourceQuery": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Properties": {
+              "ParentId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayRestApi",
+                  "RootResourceId"
+                ]
+              },
+              "PathPart": "query",
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              }
+            }
+          },
+          "ApiGatewayResourceXml": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Properties": {
+              "ParentId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayRestApi",
+                  "RootResourceId"
+                ]
+              },
+              "PathPart": "xml",
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              }
+            }
+          },
+          "ApiGatewayResourceSoap": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Properties": {
+              "ParentId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayRestApi",
+                  "RootResourceId"
+                ]
+              },
+              "PathPart": "soap",
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              }
+            }
+          },
+          "ApiGatewayMethodFormPost": {
+            "Type": "AWS::ApiGateway::Method",
+            "Properties": {
+              "HttpMethod": "POST",
+              "RequestParameters": {},
+              "ResourceId": {
+                "Ref": "ApiGatewayResourceForm"
+              },
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "ApiKeyRequired": false,
+              "AuthorizationType": "NONE",
+              "Integration": {
+                "IntegrationHttpMethod": "POST",
+                "Type": "AWS_PROXY",
+                "Uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "FormLambdaFunction",
+                          "Arn"
+                        ]
+                      },
+                      "/invocations"
+                    ]
+                  ]
+                }
+              },
+              "MethodResponses": []
+            }
+          },
+          "ApiGatewayMethodJsonPost": {
+            "Type": "AWS::ApiGateway::Method",
+            "Properties": {
+              "HttpMethod": "POST",
+              "RequestParameters": {},
+              "ResourceId": {
+                "Ref": "ApiGatewayResourceJson"
+              },
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "ApiKeyRequired": false,
+              "AuthorizationType": "NONE",
+              "Integration": {
+                "IntegrationHttpMethod": "POST",
+                "Type": "AWS_PROXY",
+                "Uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "JsonLambdaFunction",
+                          "Arn"
+                        ]
+                      },
+                      "/invocations"
+                    ]
+                  ]
+                }
+              },
+              "MethodResponses": []
+            }
+          },
+          "ApiGatewayMethodQueryPost": {
+            "Type": "AWS::ApiGateway::Method",
+            "Properties": {
+              "HttpMethod": "POST",
+              "RequestParameters": {},
+              "ResourceId": {
+                "Ref": "ApiGatewayResourceQuery"
+              },
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "ApiKeyRequired": false,
+              "AuthorizationType": "NONE",
+              "Integration": {
+                "IntegrationHttpMethod": "POST",
+                "Type": "AWS_PROXY",
+                "Uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "QueryLambdaFunction",
+                          "Arn"
+                        ]
+                      },
+                      "/invocations"
+                    ]
+                  ]
+                }
+              },
+              "MethodResponses": []
+            }
+          },
+          "ApiGatewayMethodXmlPost": {
+            "Type": "AWS::ApiGateway::Method",
+            "Properties": {
+              "HttpMethod": "POST",
+              "RequestParameters": {},
+              "ResourceId": {
+                "Ref": "ApiGatewayResourceXml"
+              },
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "ApiKeyRequired": false,
+              "AuthorizationType": "NONE",
+              "Integration": {
+                "IntegrationHttpMethod": "POST",
+                "Type": "AWS_PROXY",
+                "Uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "XmlLambdaFunction",
+                          "Arn"
+                        ]
+                      },
+                      "/invocations"
+                    ]
+                  ]
+                }
+              },
+              "MethodResponses": []
+            }
+          },
+          "ApiGatewayMethodSoapPost": {
+            "Type": "AWS::ApiGateway::Method",
+            "Properties": {
+              "HttpMethod": "POST",
+              "RequestParameters": {},
+              "ResourceId": {
+                "Ref": "ApiGatewayResourceSoap"
+              },
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "ApiKeyRequired": false,
+              "AuthorizationType": "NONE",
+              "Integration": {
+                "IntegrationHttpMethod": "POST",
+                "Type": "AWS_PROXY",
+                "Uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "SoapLambdaFunction",
+                          "Arn"
+                        ]
+                      },
+                      "/invocations"
+                    ]
+                  ]
+                }
+              },
+              "MethodResponses": []
+            }
+          },
+          "ApiGatewayDeployment1610314621121": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+              "RestApiId": {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "StageName": "dev"
+            },
+            "DependsOn": [
+              "ApiGatewayMethodFormPost",
+              "ApiGatewayMethodJsonPost",
+              "ApiGatewayMethodQueryPost",
+              "ApiGatewayMethodXmlPost",
+              "ApiGatewayMethodSoapPost"
+            ]
+          },
+          "FormLambdaPermissionApiGateway": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+              "FunctionName": {
+                "Fn::GetAtt": [
+                  "FormLambdaFunction",
+                  "Arn"
+                ]
+              },
+              "Action": "lambda:InvokeFunction",
+              "Principal": "apigateway.amazonaws.com",
+              "SourceArn": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":execute-api:",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":",
+                    {
+                      "Ref": "ApiGatewayRestApi"
+                    },
+                    "/*/*"
+                  ]
+                ]
+              }
+            }
+          },
+          "JsonLambdaPermissionApiGateway": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+              "FunctionName": {
+                "Fn::GetAtt": [
+                  "JsonLambdaFunction",
+                  "Arn"
+                ]
+              },
+              "Action": "lambda:InvokeFunction",
+              "Principal": "apigateway.amazonaws.com",
+              "SourceArn": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":execute-api:",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":",
+                    {
+                      "Ref": "ApiGatewayRestApi"
+                    },
+                    "/*/*"
+                  ]
+                ]
+              }
+            }
+          },
+          "QueryLambdaPermissionApiGateway": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+              "FunctionName": {
+                "Fn::GetAtt": [
+                  "QueryLambdaFunction",
+                  "Arn"
+                ]
+              },
+              "Action": "lambda:InvokeFunction",
+              "Principal": "apigateway.amazonaws.com",
+              "SourceArn": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":execute-api:",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":",
+                    {
+                      "Ref": "ApiGatewayRestApi"
+                    },
+                    "/*/*"
+                  ]
+                ]
+              }
+            }
+          },
+          "XmlLambdaPermissionApiGateway": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+              "FunctionName": {
+                "Fn::GetAtt": [
+                  "XmlLambdaFunction",
+                  "Arn"
+                ]
+              },
+              "Action": "lambda:InvokeFunction",
+              "Principal": "apigateway.amazonaws.com",
+              "SourceArn": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":execute-api:",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":",
+                    {
+                      "Ref": "ApiGatewayRestApi"
+                    },
+                    "/*/*"
+                  ]
+                ]
+              }
+            }
+          },
+          "SoapLambdaPermissionApiGateway": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+              "FunctionName": {
+                "Fn::GetAtt": [
+                  "SoapLambdaFunction",
+                  "Arn"
+                ]
+              },
+              "Action": "lambda:InvokeFunction",
+              "Principal": "apigateway.amazonaws.com",
+              "SourceArn": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":execute-api:",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":",
+                    {
+                      "Ref": "ApiGatewayRestApi"
+                    },
+                    "/*/*"
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "Outputs": {
+          "ServerlessDeploymentBucketName": {
+            "Value": {
+              "Ref": "ServerlessDeploymentBucket"
+            }
+          },
+          "FormLambdaFunctionQualifiedArn": {
+            "Description": "Current Lambda function version",
+            "Value": {
+              "Ref": "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0"
+            }
+          },
+          "JsonLambdaFunctionQualifiedArn": {
+            "Description": "Current Lambda function version",
+            "Value": {
+              "Ref": "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY"
+            }
+          },
+          "QueryLambdaFunctionQualifiedArn": {
+            "Description": "Current Lambda function version",
+            "Value": {
+              "Ref": "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8"
+            }
+          },
+          "XmlLambdaFunctionQualifiedArn": {
+            "Description": "Current Lambda function version",
+            "Value": {
+              "Ref": "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY"
+            }
+          },
+          "SoapLambdaFunctionQualifiedArn": {
+            "Description": "Current Lambda function version",
+            "Value": {
+              "Ref": "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw"
+            }
+          },
+          "ServiceEndpoint": {
+            "Description": "URL of the service endpoint",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  "https://",
+                  {
+                    "Ref": "ApiGatewayRestApi"
+                  },
+                  ".execute-api.",
+                  {
+                    "Ref": "AWS::Region"
+                  },
+                  ".",
+                  {
+                    "Ref": "AWS::URLSuffix"
+                  },
+                  "/dev"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      "coreCloudFormationTemplate": {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "The AWS CloudFormation template for this Serverless application",
+        "Resources": {
+          "ServerlessDeploymentBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+              "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                  {
+                    "ServerSideEncryptionByDefault": {
+                      "SSEAlgorithm": "AES256"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ServerlessDeploymentBucketPolicy": {
+            "Type": "AWS::S3::BucketPolicy",
+            "Properties": {
+              "Bucket": {
+                "Ref": "ServerlessDeploymentBucket"
+              },
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": "s3:*",
+                    "Effect": "Deny",
+                    "Principal": "*",
+                    "Resource": [
+                      {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:",
+                            {
+                              "Ref": "AWS::Partition"
+                            },
+                            ":s3:::",
+                            {
+                              "Ref": "ServerlessDeploymentBucket"
+                            },
+                            "/*"
+                          ]
+                        ]
+                      },
+                      {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:",
+                            {
+                              "Ref": "AWS::Partition"
+                            },
+                            ":s3:::",
+                            {
+                              "Ref": "ServerlessDeploymentBucket"
+                            }
+                          ]
+                        ]
+                      }
+                    ],
+                    "Condition": {
+                      "Bool": {
+                        "aws:SecureTransport": false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "Outputs": {
+          "ServerlessDeploymentBucketName": {
+            "Value": {
+              "Ref": "ServerlessDeploymentBucket"
+            }
+          }
+        }
+      },
+      "vpc": {}
+    },
+    "pluginsData": {},
+    "functions": {
+      "form": {
+        "handler": "lambda.form",
+        "name": "leadconduit-custom-outbound-form",
+        "events": [
+          {
+            "http": {
+              "path": "form",
+              "method": "post",
+              "integration": "AWS_PROXY"
+            }
+          }
+        ],
+        "package": {},
+        "memory": 128,
+        "timeout": 30,
+        "runtime": "nodejs12.x",
+        "vpc": {},
+        "versionLogicalId": "FormLambdaVersionQerCyBJcXiksNcsOYIyncg47NeSFVE61avtqK92vQm0"
+      },
+      "json": {
+        "handler": "lambda.json",
+        "name": "leadconduit-custom-outbound-json",
+        "events": [
+          {
+            "http": {
+              "path": "json",
+              "method": "post",
+              "integration": "AWS_PROXY"
+            }
+          }
+        ],
+        "package": {},
+        "memory": 128,
+        "timeout": 30,
+        "runtime": "nodejs12.x",
+        "vpc": {},
+        "versionLogicalId": "JsonLambdaVersionrmp4cyrDCRI8njnaFBx1Rlwy1vqgH4DJPU7kyG0KY"
+      },
+      "query": {
+        "handler": "lambda.query",
+        "name": "leadconduit-custom-outbound-query",
+        "events": [
+          {
+            "http": {
+              "path": "query",
+              "method": "post",
+              "integration": "AWS_PROXY"
+            }
+          }
+        ],
+        "package": {},
+        "memory": 128,
+        "timeout": 30,
+        "runtime": "nodejs12.x",
+        "vpc": {},
+        "versionLogicalId": "QueryLambdaVersionJJzam26oJjFuMtgfod1z5xZSWTim5nVX9GpmN2wQ8"
+      },
+      "xml": {
+        "handler": "lambda.xml",
+        "name": "leadconduit-custom-outbound-xml",
+        "events": [
+          {
+            "http": {
+              "path": "xml",
+              "method": "post",
+              "integration": "AWS_PROXY"
+            }
+          }
+        ],
+        "package": {},
+        "memory": 128,
+        "timeout": 30,
+        "runtime": "nodejs12.x",
+        "vpc": {},
+        "versionLogicalId": "XmlLambdaVersionZXxv2zLvSpLk1jw5FQgxG2vTuM041mW9tHdLoZN9oAY"
+      },
+      "soap": {
+        "handler": "lambda.soap",
+        "name": "leadconduit-custom-outbound-soap",
+        "events": [
+          {
+            "http": {
+              "path": "soap",
+              "method": "post",
+              "integration": "AWS_PROXY"
+            }
+          }
+        ],
+        "package": {},
+        "memory": 128,
+        "timeout": 30,
+        "runtime": "nodejs12.x",
+        "vpc": {},
+        "versionLogicalId": "SoapLambdaVersionvyNkPLofkrJZoFwmEYLvRZYWTYZvay1yidbLy9LUEw"
+      }
+    },
+    "configValidationMode": "warn",
+    "serviceFilename": "serverless.yml",
+    "layers": {},
+    "initialServerlessConfig": {
+      "service": {
+        "$ref": "$[\"service\"][\"serviceObject\"]"
+      },
+      "frameworkVersion": ">=2.1.0 <3.0.0",
+      "provider": {
+        "$ref": "$[\"service\"][\"provider\"]"
+      },
+      "package": {
+        "exclude": [
+          ".git/**",
+          ".github/**",
+          ".rip/pkg/*",
+          ".serverless/**",
+          "coverage/**",
+          "docs/**",
+          "lib/ui/**",
+          "pkg/**",
+          "spec/**",
+          "src/**",
+          "test/**",
+          ".eslintrc.js",
+          ".gitignore",
+          ".npmignore",
+          ".npmrc",
+          ".nyc_output",
+          ".travis.yml",
+          "Cakefile",
+          "CHANGELOG.md",
+          "Readme.md",
+          "README.md"
+        ],
+        "artifact": "/Users/michaelbetts/repos/leadconduit-integration-custom/.serverless/leadconduit-custom.zip",
+        "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z"
+      },
+      "functions": {
+        "$ref": "$[\"service\"][\"functions\"]"
+      }
+    },
+    "isDashboardMonitoringPreconfigured": false,
+    "artifact": "/Users/michaelbetts/repos/leadconduit-integration-custom/.serverless/leadconduit-custom.zip"
+  },
+  "package": {
+    "artifactDirectoryName": "serverless/leadconduit-custom/dev/1610314629861-2021-01-10T21:37:09.861Z",
+    "artifact": "leadconduit-custom.zip"
+  }
+}

--- a/.rip/runner.js
+++ b/.rip/runner.js
@@ -1,0 +1,171 @@
+
+// Lambda Integration Runner
+
+const _ = require('lodash');
+const Promise = require('bluebird');
+// const request = Promise.promisify(require('request'), { multiArgs: true });
+const Parser = require('leadconduit-integration').test.types.parser;
+const AWSXRay = require('aws-xray-sdk-core');
+const AWS = AWSXRay.captureAWS(require('aws-sdk'));
+AWSXRay.captureHTTPsGlobal(require('http'));
+
+let integration;
+
+function handler (integrationObj, event, context, callback) {
+  let response;
+
+  integration = integrationObj;
+
+  // If invoked via a warmup event, we're done
+  if (isWarmupEvent(event)) {
+    callback(null, 'function is warm');
+    return;
+  }
+
+  getInput(event)
+    .then(validate)
+    .then(run)
+    .then(processResults)
+    .then(results => {
+      console.log('responding');
+      response = buildResponse(results);
+      console.log(response);
+      callback(null, response);
+    })
+    .catch(IntegrationError, e => {
+      console.log('caught integration error');
+      response = e.buildResponse();
+      callback(null, response);
+    })
+    .catch(e => {
+      console.log('caught exception');
+      callback(e);
+    });
+}
+
+function isWarmupEvent (event) {
+  return (event.source === 'serverless-plugin-warmup');
+}
+
+function getInput (event) {
+  console.log('in getInput', event);
+
+  // While a promise isn't necessary here, it is cleaner to start the chain here
+  return new Promise((resolve, reject) => {
+    let body;
+
+    try {
+      // TODO: for SQS need to handle multiple records
+
+      // If from API gateway
+      if (event.httpMethod) {
+        const b = JSON.parse(event.body);
+        const parser = Parser(integration.request.variables());
+        body = parser(b);
+      }
+
+      // If from SQS
+      else if (event.Records) {
+        body = JSON.parse(event.Records[0].body);
+        console.log('sqs body', body);
+      }
+
+      // Direct
+      else {
+        body = event;
+      }
+
+      if (!body) {
+        reject(new IntegrationError(400, 'no body'));
+        return;
+      }
+    } catch (e) {
+      reject(new IntegrationError(400, 'parse failed'));
+      return;
+    }
+
+    console.log('integration', integration);
+    console.log('BODY', body);
+    resolve(body);
+  });
+}
+
+function validate (vars) {
+  console.log('in validate');
+
+  if (!_.isFunction(integration.validate)) {
+    console.log('optional validate function not found');
+    return vars;
+  }
+
+  const message = integration.validate(vars);
+  if (message) {
+    console.log(message);
+    throw new IntegrationError(422, 'validation failed', { message });
+  }
+  return vars;
+}
+
+function run (vars) {
+  console.log('in run');
+
+  return new Promise((resolve, reject) => {
+    if (!_.isFunction(integration.handle)) {
+      throw new IntegrationError(400, 'Handle is not a function');
+    }
+
+    integration.handle(vars, (err, append) => {
+      console.log('in run callback, err:', err);
+      console.log('in run callback, append:', append);
+      if (err && !(err instanceof Error)) {
+        console.log(err);
+        reject(new IntegrationError(400, 'Error returned by integration must be an instance of Error'));
+      }
+
+      if (!append) {
+        reject(new IntegrationError(400, 'No event returned from integration'));
+      }
+
+      resolve(append);
+    });
+  });
+}
+
+function processResults (results) {
+  console.log('in processResults', results);
+  return new Promise((resolve, reject) => {
+    resolve(results);
+  });
+}
+
+function buildResponse (results) {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify(results)
+  };
+  return response;
+}
+
+class IntegrationError extends Error {
+  constructor (statusCode, message = 'unknown error', body = {}) {
+    super();
+    this.statusCode = statusCode;
+    this.message = message;
+    this.body = body;
+  }
+
+  buildResponse () {
+    const outcome = 'error';
+    const reason = this.message;
+    const stack = this.stack.split('\n');
+    const event = { outcome, reason };
+    const integration = this.body;
+    const response = {
+      statusCode: this.statusCode,
+      body: JSON.stringify({ event, integration: { stack, integration } })
+    };
+    return response;
+  }
+}
+
+module.exports = handler;

--- a/.rip/runner.js
+++ b/.rip/runner.js
@@ -3,7 +3,6 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
-// const request = Promise.promisify(require('request'), { multiArgs: true });
 const Parser = require('leadconduit-integration').test.types.parser;
 const AWSXRay = require('aws-xray-sdk-core');
 const AWS = AWSXRay.captureAWS(require('aws-sdk'));
@@ -33,13 +32,12 @@ function handler (integrationObj, event, context, callback) {
       callback(null, response);
     })
     .catch(IntegrationError, e => {
-      console.log('caught integration error');
       response = e.buildResponse();
-      console.log( response );
+      console.error('caught integration error', response);
       callback(null, response);
     })
     .catch(e => {
-      console.log('caught exception');
+      console.error('caught exception', e);
       callback(e);
     });
 }
@@ -90,7 +88,7 @@ function getInput (event) {
         return;
       }
     } catch (e) {
-      console.log(e);
+      console.error(e);
       reject(new IntegrationError(400, 'parse failed'));
       return;
     }
@@ -129,7 +127,7 @@ function run (vars) {
       console.log('in run callback, err:', err);
       console.log('in run callback, append:', append);
       if (err && !(err instanceof Error)) {
-        console.log(err);
+        console.error(err);
         reject(new IntegrationError(400, 'Error returned by integration must be an instance of Error'));
       }
 

--- a/lambda.js
+++ b/lambda.js
@@ -1,0 +1,36 @@
+
+// Lambda Adapter for leadconduit-custom
+// Generated on Thu Jan 07 2021 13:15:23 GMT-0500 (Eastern Standard Time)
+
+const runner = require('.rip/runner');
+const handle = require('.rip/handle');
+
+function form( event, context, callback ) {
+    const integration = handle.create('form');
+    return runner( integration, event, context, callback );
+}
+function json( event, context, callback ) {
+    const integration = handle.create('json');
+    return runner( integration, event, context, callback );
+}
+function query( event, context, callback ) {
+    const integration = handle.create('query');
+    return runner( integration, event, context, callback );
+}
+function xml( event, context, callback ) {
+    const integration = handle.create('xml');
+    return runner( integration, event, context, callback );
+}
+function soap( event, context, callback ) {
+    const integration = handle.create('soap');
+    return runner( integration, event, context, callback );
+}
+
+let lambda = {};
+lambda.form = form;
+lambda.json = json;
+lambda.query = query;
+lambda.xml = xml;
+lambda.soap = soap;
+
+module.exports = lambda;

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,82 @@
+
+# LeadConduit custom integration
+# generated on Sun Jan 10 2021 16:36:41 GMT-0500 (Eastern Standard Time)
+
+service: leadconduit-custom
+
+# Pin serverless framework to v2
+frameworkVersion: ">=2.1.0 <3.0.0"
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  memorySize: 128
+  timeout: 30
+  environment:
+    NODE_ENV: ${opt:stage,'development'}
+
+package:
+  exclude:
+  - .git/**
+  - .github/**
+  - .rip/pkg/*
+  - .serverless/**
+  - coverage/**
+  - docs/**
+  - lib/ui/**
+  - pkg/**
+  - spec/**
+  - src/**
+  - test/**
+  - .eslintrc.js
+  - .gitignore
+  - .npmignore
+  - .npmrc
+  - .nyc_output
+  - .travis.yml
+  - Cakefile
+  - CHANGELOG.md
+  - Readme.md
+  - README.md
+
+functions:
+  form:
+    handler: lambda.form
+    name: leadconduit-custom-outbound-form
+    events:
+      - http:
+          path: form
+          method: POST
+
+  json:
+    handler: lambda.json
+    name: leadconduit-custom-outbound-json
+    events:
+      - http:
+          path: json
+          method: POST
+
+  query:
+    handler: lambda.query
+    name: leadconduit-custom-outbound-query
+    events:
+      - http:
+          path: query
+          method: POST
+
+  xml:
+    handler: lambda.xml
+    name: leadconduit-custom-outbound-xml
+    events:
+      - http:
+          path: xml
+          method: POST
+
+  soap:
+    handler: lambda.soap
+    name: leadconduit-custom-outbound-soap
+    events:
+      - http:
+          path: soap
+          method: POST
+


### PR DESCRIPTION
This adds the retry lambda wrapper around the integration.  It should have no effect on regular integration use. The .rip folder has a pkg/leadconduit-custom.zip that is the lambda distribution and should not be in git.  It and the other lambda files should also not be published to npm. 