### PR TITLE
Allow error as outcome on match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.18.6] - 2021-02-22
+### Added
+- Allow setting outcome on match to `error`
+
 ## [2.18.5] - 2020-06-30
 ### Added
 - JSON integration now supports the extra nested parameters variable

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -33,7 +33,7 @@ const method = function(vars, allowed) {
 const outcome = function(vars) {
   if (!vars.outcome_on_match) { return; }
 
-  if ((vars.outcome_on_match !== 'success') && (vars.outcome_on_match !== 'failure')) {
+  if ((vars.outcome_on_match !== 'success') && (vars.outcome_on_match !== 'failure') && (vars.outcome_on_match !== 'error')) {
     return "Outcome on match must be 'success' or 'failure'";
   }
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -34,7 +34,7 @@ const outcome = function(vars) {
   if (!vars.outcome_on_match) { return; }
 
   if ((vars.outcome_on_match !== 'success') && (vars.outcome_on_match !== 'failure') && (vars.outcome_on_match !== 'error')) {
-    return "Outcome on match must be 'success' or 'failure'";
+    return "Outcome on match must be 'success', 'failure', or 'error'";
   }
 };
 

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -1,7 +1,7 @@
 module.exports = [
   { name: 'outcome_search_term', description: 'The text to search for in the response. When found outcome will be "success". Regular expressions are allowed. Pro tip: Use Outcome on Match to use this term to search for "failure" instead of "success".', type: 'string', required: false },
   { name: 'outcome_search_path', description: 'Narrow the search scope using dot-notation path (for JSON responses), XPath (for XML responses), or CSS selector (for HTML responses)', type: 'string', required: false },
-  { name: 'outcome_on_match', description: 'The outcome when the search term is found - "success" or "failure" (default: success)', type: 'string', required: false },
+  { name: 'outcome_on_match', description: 'The outcome when the search term is found - "success" or "failure" or "error" (default: success)', type: 'string', required: false },
   { name: 'reason_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the failure reason', type: 'string', required: false },
   { name: 'price_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the lead price', type: 'string', required: false },
   { name: 'default_reason', description: 'Failure reason when no reason can be found per the optional Reason Path setting', type: 'string', required: false },

--- a/test/form-spec.js
+++ b/test/form-spec.js
@@ -216,6 +216,7 @@ describe('Outbound Form POST validation', function() {
 
   it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
 
+  it('should allow setting error outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
 
   it('should pass validation', () => assert.isUndefined(integration.validate({url: 'http://foo'})));
 

--- a/test/form-spec.js
+++ b/test/form-spec.js
@@ -214,7 +214,7 @@ describe('Outbound Form POST validation', function() {
   it('should require valid URL', () => assert.equal(integration.validate({}), 'URL is required'));
 
 
-  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
+  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success', 'failure', or 'error'"));
 
   it('should allow setting error outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
 

--- a/test/json-spec.js
+++ b/test/json-spec.js
@@ -287,6 +287,8 @@ describe('JSON validation', function() {
 
   it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
 
+  it('should allow setting error outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
+
   it('should pass validation', () => assert.isUndefined(integration.validate({url: 'http://foo'})));
 
   it('should allow valid content-type header', () => assert.isUndefined(integration.validate({url: 'http://foo', header: { 'Content-Type': 'application/json' }})));

--- a/test/json-spec.js
+++ b/test/json-spec.js
@@ -285,7 +285,7 @@ describe('JSON validation', function() {
 
   it('should require valid method', () => assert.equal(integration.validate({url: 'http://foo', method: 'HEAD'}), 'Unsupported HTTP method - use POST, PUT, DELETE'));
 
-  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
+  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success', 'failure', or 'error'"));
 
   it('should allow setting error outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
 

--- a/test/query-spec.js
+++ b/test/query-spec.js
@@ -159,6 +159,8 @@ describe('Outbound GET Query validation', function() {
 
   it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
 
+  it('should allow setting error outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
+
 
   it('should pass validation', () => assert.isUndefined(integration.validate({url: 'http://foo'})));
 

--- a/test/query-spec.js
+++ b/test/query-spec.js
@@ -157,7 +157,7 @@ describe('Outbound GET Query validation', function() {
   it('should require valid URL', () => assert.equal(integration.validate({}), 'URL is required'));
 
 
-  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
+  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success', 'failure', or 'error'"));
 
   it('should allow setting error outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
 

--- a/test/soap-spec.js
+++ b/test/soap-spec.js
@@ -896,6 +896,7 @@ describe('Outbound SOAP', function() {
 
     it('should require valid search outcome', () => assert.equal(soap.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
 
+    it('should allow setting error outcome', () => assert.isUndefined(soap.validate({url: 'http://foo', outcome_on_match: 'error', function: 'whatever'})));
 
     it('should pass validation', () => assert.isUndefined(soap.validate({url: 'http://foo', function: 'whatever'})));
 

--- a/test/soap-spec.js
+++ b/test/soap-spec.js
@@ -894,7 +894,7 @@ describe('Outbound SOAP', function() {
     });
 
 
-    it('should require valid search outcome', () => assert.equal(soap.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
+    it('should require valid search outcome', () => assert.equal(soap.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success', 'failure', or 'error'"));
 
     it('should allow setting error outcome', () => assert.isUndefined(soap.validate({url: 'http://foo', outcome_on_match: 'error', function: 'whatever'})));
 

--- a/test/xml-spec.js
+++ b/test/xml-spec.js
@@ -330,7 +330,7 @@ describe('XML validation', function() {
   it('should require valid method', () => assert.equal(integration.validate({url: 'http://foo', method: 'HEAD'}), 'Unsupported HTTP method - use POST, PUT'));
 
 
-  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
+  it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success', 'failure', or 'error'"));
 
   it('should require valid search outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
 

--- a/test/xml-spec.js
+++ b/test/xml-spec.js
@@ -332,6 +332,7 @@ describe('XML validation', function() {
 
   it('should require valid search outcome', () => assert.equal(integration.validate({url: 'http://foo', outcome_on_match: 'donkey'}), "Outcome on match must be 'success' or 'failure'"));
 
+  it('should require valid search outcome', () => assert.isUndefined(integration.validate({url: 'http://foo', outcome_on_match: 'error'})));
 
   it('should pass validation', () => assert.isUndefined(integration.validate({url: 'http://foo'})));
 


### PR DESCRIPTION
## Description of the change

This change allows users to supply `error` to the `outcome_on_match` mapping. Functionally, this makes it so that we can explicitly define behavior that causes the integration to return an `error`. 

Also, the test formatting is gnarly. A leftover from decaffeination. My b. I'll try and fix this sometime this week, because they aren't fun to look at 😅

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Documentation

## Related tickets

https://app.clubhouse.io/active-prospect/story/19013/allow-error-to-be-mapped-to-outcome-on-match

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  This branch has been rebased off master to be current.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.

### Tracking 
- [x]  Issue from Clubhouse has a link to this pull request.
- [x]  This PR has a link to the issue in Clubhouse.

### QA
- [x]  This branch has been deployed to staging and tested.

