### PR TITLE
fix array response handling

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.19.3] - 2022-05-20
+### Fixed
+- array responses are now appended under an `array.` property
+
 ## [2.19.1] - 2021-02-25
 ### Fixed
 - fix npm vulnerabilities

--- a/lib/response.js
+++ b/lib/response.js
@@ -32,6 +32,10 @@ const response = function(vars, req, res) {
     doc = toDoc(res.body, res.headers['Content-Type']);
   }
 
+  if (_.isArray(doc)) {
+    doc = { array: doc }
+  }
+
   // default to success if no search term and no outcome are specified
   if (!vars.outcome_search_term && !vars.outcome_on_match) {
     outcome = 'success';
@@ -46,7 +50,7 @@ const response = function(vars, req, res) {
         // this is an XML document
         try {
           searchIn = doc.xpath(searchPath, true);
-        } 
+        }
         catch (error3) {}
 
       } else if (_.isFunction(doc.html)) {
@@ -90,7 +94,7 @@ const response = function(vars, req, res) {
       // this is a XML document
       try {
         price = doc.xpath(priceSelector, true);
-      } 
+      }
       catch (error4) {}
 
     } else if (_.isFunction(doc.html)) {
@@ -234,7 +238,8 @@ response.variables = () => [
   { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' },
   { name: 'cookie', type: 'string', description: 'The full cookie header string captured via match with \'cookie_search_term\'' },
   { name: 'price', type: 'number', description: 'The price of the lead' },
-  { name: '*', type: 'wildcard' }
+  { name: '*', type: 'wildcard' },
+  { name: 'array.*', type: 'wildcard', description: 'If the response is an array appended fields will be found under this property' }
 ];
 
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -238,8 +238,7 @@ response.variables = () => [
   { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' },
   { name: 'cookie', type: 'string', description: 'The full cookie header string captured via match with \'cookie_search_term\'' },
   { name: 'price', type: 'number', description: 'The price of the lead' },
-  { name: '*', type: 'wildcard' },
-  { name: 'array.*', type: 'wildcard', description: 'If the response is an array appended fields will be found under this property' }
+  { name: '*', type: 'wildcard' }
 ];
 
 

--- a/test/response-spec.js
+++ b/test/response-spec.js
@@ -461,6 +461,17 @@ describe('Response', function() {
       }
       assert.deepEqual(response({}, {}, json([{foo: 'foo'}, {bar: 'bar'}])), expected)
     });
+
+    it('should correctly handle numeric JSON strings', () => {
+      const expected = {
+        outcome: 'success',
+        price: 0,
+        '0': {
+          foo: 'foo'
+        }
+      };
+      assert.deepEqual(response({}, {}, json({ '0': { foo: 'foo' }})), expected);
+    })
   });
 
 

--- a/test/response-spec.js
+++ b/test/response-spec.js
@@ -279,12 +279,15 @@ describe('Response', function() {
     it('should parse reason from array response', function() {
       const vars = {
         outcome_search_term: 'foo',
-        reason_path: '0.bip'
+        reason_path: 'array.0.bip'
       };
       const expected = {
         outcome: 'failure',
         reason: 'the reason text!',
-        price: 0
+        price: 0,
+        array: [
+          { bip: 'the reason text!' }
+        ]
       };
       assert.deepEqual(response(vars, {}, json( [ {bip: 'the reason text!'} ] )), expected);
     });
@@ -367,7 +370,7 @@ describe('Response', function() {
         },
         price: 0
       };
-         
+
       assert.deepEqual(response(vars, {}, json({baz: { foo: { details: { bip: { more_details : 'really bad data'}}}}})), expected);
     });
 
@@ -415,7 +418,7 @@ describe('Response', function() {
     });
 
     it('should capture price on success', function() {
-      const vars = 
+      const vars =
         {price_path: 'baz.*.cost'};
       const expected = {
         outcome: 'success',
@@ -428,9 +431,9 @@ describe('Response', function() {
       };
       assert.deepEqual(response(vars, {}, json({baz: { foo: { cost: 1.5 }}})), expected);
     });
-    
+
     it('should capture price on success with outcome_search_term', function() {
-      const vars = { 
+      const vars = {
         price_path: 'price',
         outcome_search_term: 'success'
       };
@@ -442,9 +445,25 @@ describe('Response', function() {
       };
       assert.deepInclude(response(vars, {}, json({ status:"success", price:18, auth_code:"abc==" })), expected);
     });
+
+    it('should capture json array body', () => {
+      const expected = {
+        outcome: 'success',
+        price: 0,
+        array: [
+          {
+            foo: 'foo'
+          },
+          {
+            bar: 'bar'
+          }
+        ]
+      }
+      assert.deepEqual(response({}, {}, json([{foo: 'foo'}, {bar: 'bar'}])), expected)
+    });
   });
 
- 
+
 
   describe('with plain text body', function() {
 
@@ -572,9 +591,9 @@ describe('Response', function() {
     });
 
     it('should capture price when vars.cost is present', function() {
-      const vars = 
+      const vars =
         {price_path: '/cost=([0-9]\.[0-9])/'};
-      const expected = { 
+      const expected = {
         outcome: 'success',
         price: '1.5'
       };
@@ -779,7 +798,7 @@ describe('Response', function() {
     it('should capture price when price_path is present', function() {
       const vars =
         {price_path: 'div.cost'};
-      const expected = { 
+      const expected = {
         outcome: 'success',
         price: "1.5"
       };


### PR DESCRIPTION
## Description of the change

The integration now appends array responses under an `array.*` parameter. I'm not totally sold on this being an ideal solution, but it was the best I could come up with.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.clubhouse.io/active-prospect/story/23581/json-array-not-appended-by-get-integration

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Clubhouse has a link to this pull request.
- [ ]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
