### PR TITLE
Allow for a fallback price to be used if price cannot be determined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.22.0]- 2022-08-25
+### Added
+- added support for fallback_price
+
 ## [2.21.2] - 2022-07-05
 ### Fixed
 - allow private IP/domains for local and test Node Environments

--- a/lib/response.js
+++ b/lib/response.js
@@ -143,7 +143,7 @@ const response = function(vars, req, res) {
 
   if (event == null) { event = {}; }
   event.outcome = outcome;
-  event.price = price || 0;
+  event.price = price || vars.fallback_price || 0;
   if (reason) { event.reason = reason; }
   if (cookie) { event.cookie = cookie; }
   if (reference) { event.reference = reference; }

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -177,7 +177,7 @@ const handle = function(vars, callback) {
       const event = result;
       event.outcome = outcome;
       if (reason) { event.reason = reason; }
-      event.price = price || 0;
+      event.price = price || vars.fallback_price || 0;
       event.reference = reference;
 
       // return the event

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -4,6 +4,7 @@ module.exports = [
   { name: 'outcome_on_match', description: 'The outcome when the search term is found - "success" or "failure" or "error" (default: success)', type: 'string', required: false },
   { name: 'reason_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the failure reason', type: 'string', required: false },
   { name: 'price_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the lead price', type: 'string', required: false },
+  { name: 'fallback_price', description: 'The fallback price to use if the price_path fails to parse a price from the response.', type: 'string', required: false },
   { name: 'reference_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the reference ID', type: 'string', required: false },
   { name: 'default_reason', description: 'Failure reason when no reason can be found per the optional Reason Path setting', type: 'string', required: false },
   { name: 'header.*', description: 'HTTP header to send in the request', type: 'wildcard', required: false },

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -4,7 +4,7 @@ module.exports = [
   { name: 'outcome_on_match', description: 'The outcome when the search term is found - "success" or "failure" or "error" (default: success)', type: 'string', required: false },
   { name: 'reason_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the failure reason', type: 'string', required: false },
   { name: 'price_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the lead price', type: 'string', required: false },
-  { name: 'fallback_price', description: 'The fallback price to use if the price_path fails to parse a price from the response.', type: 'string', required: false },
+  { name: 'fallback_price', description: 'The fallback price to use if the price_path fails to parse a price from the response.', type: 'number', required: false },
   { name: 'reference_path', description: 'The dot-notation path (for JSON responses), XPath location (for XML responses), or regular expression with a single capture group, used to find the reference ID', type: 'string', required: false },
   { name: 'default_reason', description: 'Failure reason when no reason can be found per the optional Reason Path setting', type: 'string', required: false },
   { name: 'header.*', description: 'HTTP header to send in the request', type: 'wildcard', required: false },

--- a/test/response-spec.js
+++ b/test/response-spec.js
@@ -446,6 +446,40 @@ describe('Response', function() {
       assert.deepInclude(response(vars, {}, json({ status:"success", price:18, auth_code:"abc==" })), expected);
     });
 
+    it('does not use fallback_price if price_path can be evaluated', function () {
+      const vars = {
+        price_path: 'baz.foo.cost',
+        fallback_price: '12.50'
+      };
+      const expected = {
+        outcome: 'success',
+        price: '1.5',
+        baz: {
+          foo: {
+            cost: 1.5
+          }
+        }
+      };
+      assert.deepEqual(response(vars, {}, json({ baz: { foo: { cost: 1.5 } } })), expected);
+    });
+
+    it('uses fallback_price if price_path cannot be evaluated', function () {
+      const vars = {
+        price_path: 'invalid_path',
+        fallback_price: '12.50'
+      };
+      const expected = {
+        outcome: 'success',
+        price: '12.50',
+        baz: {
+          foo: {
+            cost: 1.5
+          }
+        }
+      };
+      assert.deepEqual(response(vars, {}, json({ baz: { foo: { cost: 1.5 } } })), expected);
+    });
+
     it('should capture reference on success', function() {
       const vars = {
         reference_path: 'baz.*.reference'

--- a/test/soap-spec.js
+++ b/test/soap-spec.js
@@ -878,6 +878,17 @@ describe('Outbound SOAP', function() {
       });
     });
 
+    it('uses fallback_price if price_path cannot be evaluated', function(done) {
+      this.vars.price_path = 'InvalidPath';
+      this.vars.fallback_price = '12.50';
+      soap.handle(this.vars, (err, event) => {
+        if (err) { done(err); }
+        assert.equal(event.outcome, 'success');
+        assert.equal(event.price, 12.50);
+        done();
+      });
+    });
+
     it('should capture reference', function(done) {
       this.vars.reference_path = 'AddLeadResult.Reference';
       soap.handle(this.vars, (err, event) => {


### PR DESCRIPTION
## Description of the change
When a price_path is passed, the integration attempts to parse the price from the response given the instructions in the price_path. If that fails, a price of 0 is returned. This allows for an optional fallback_price to be provided in the case that the price cannot be parsed from the response before finally defaulting to 0. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/39611/user-selects-pre-configured-pricing-service-in-pricing-configuration

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
