### PR TITLE
remove unneeded env & set v2 for serverless

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -23,9 +23,7 @@ jobs:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Install Serverless Framework
-      run: npm i serverless
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm i serverless@2
 
     - name: Install rip-cli
       run: npm i -g @activeprospect/rip-cli


### PR DESCRIPTION
## Description of the change

Trying to fix the next deploy error, where the `rip run deploy` fails because the installed `serverless` (v3) is newer than needed by `rip-cli` (v2)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/45351/360connect-automated-retry-is-not-retrying-leads-and-in-some-cases-sending-leads-multiple-times-duplicated

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
