### PR TITLE
Sc 51845/make custom integration able to follow all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.23.0]- 2023-04-25
 ### Added
-- add support for `follow_redirects` request variable flag to JSON, form, and XML integrations ([sc-51845](https://app.shortcut.com/active-prospect/story/51845/make-custom-integration-able-to-follow-all-redirects)
+- add support for `follow_redirects` request variable flag to JSON, form, query, & XML integrations ([sc-51845](https://app.shortcut.com/active-prospect/story/51845/make-custom-integration-able-to-follow-all-redirects)
 
 ## [2.22.0]- 2022-08-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.23.0]- 2023-04-25
+### Added
+- add support for `follow_redirects` request variable flag to JSON, form, and XML integrations ([sc-51845](https://app.shortcut.com/active-prospect/story/51845/make-custom-integration-able-to-follow-all-redirects)
+
 ## [2.22.0]- 2022-08-25
 ### Added
 - added support for fallback_price

--- a/Cakefile
+++ b/Cakefile
@@ -1,1 +1,0 @@
-require('leadconduit-cakefile')(task)

--- a/lib/form.js
+++ b/lib/form.js
@@ -20,11 +20,11 @@ const request = function(vars) {
   // user-defined form field values
   const formFields = vars.form_field != null ? vars.form_field : {};
   const encodeValuesOnly = (vars.encode_form_field_names != null) && !(_.result(vars, 'encode_form_fields.valueOf'));
-  
+
   // build body content
   const normalized = normalize(formFields, _.result(vars, 'send_ascii.valueOf', false), encodeValuesOnly);
   const content = flat.flatten(compact(normalized), {safe: true});
-  
+
   // URL encode post body
   let body;
   if (encodeValuesOnly) {
@@ -47,6 +47,7 @@ const request = function(vars) {
     url: vars.url,
     method: 'POST',
     headers: _.merge(defaultHeaders, headers(vars.header)),
+    followAllRedirects: !!vars.follow_redirects,
     body
   };
 };

--- a/lib/json.js
+++ b/lib/json.js
@@ -59,6 +59,7 @@ const request = function(vars) {
     url: vars.url,
     method: _.result(vars, 'method.toUpperCase', 'POST'),
     headers: _.merge(defaultHeaders, headers(vars.header)),
+    followAllRedirects: !!vars.follow_redirects,
     body
   };
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -32,9 +32,13 @@ const request = function(vars) {
     defaultHeaders['Authorization'] = helpers.encodeBasicAuth(vars.basic_username, vars.basic_password);
   }
 
+  // following redirects is default behavior for GET requests; check for false
+  const followRedirects = _.isUndefined(vars.follow_redirects) ? true : !!vars.follow_redirects;
+
   return {
     url: `${vars.url}?${query}`,
     method: 'GET',
+    followAllRedirects: followRedirects,
     headers: _.merge(defaultHeaders, headers(vars.header))
   };
 };
@@ -64,7 +68,7 @@ module.exports = {
   request,
   response,
   validate: function(vars) {
-    return validate.url(vars) || 
+    return validate.url(vars) ||
            validate.outcome(vars) ||
            validate.headers(vars, 'No_Content_Type_allowed_for_GET');
   }

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -11,5 +11,6 @@ module.exports = [
   { name: 'send_ascii', description: 'Set to true to ensure lead data is sent as ASCII for legacy recipients (default: false)', type: 'boolean', required: false },
   { name: 'capture.*', description: 'A named regular expression with a single capture group, used to capture values from plain text responses into the named property', type: 'wildcard' },
   { name: 'response_content_type_override', description: "Override response's Content-Type header with custom value.", type: 'string', required: false },
-  { name: 'cookie_search_term', description: "The text to search for to identify an HTTP cookie. Usually the cookie 'name' is sufficient; regular expressions are allowed", type: 'string', required: false }
+  { name: 'cookie_search_term', description: "The text to search for to identify an HTTP cookie. Usually the cookie 'name' is sufficient; regular expressions are allowed", type: 'string', required: false },
+  { name: 'follow_redirects', description: 'If true, follow redirects even on methods other than GET (default: false)', type: 'boolean', required: false }
 ];

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -38,6 +38,7 @@ const request = function(vars) {
     url: vars.url,
     method: _.result(vars, 'method.toUpperCase') || 'POST',
     headers: _.merge(defaultHeaders, headers(vars.header)),
+    followAllRedirects: !!vars.follow_redirects,
     body
   };
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "dot-wild": "^3.0.1",
-    "flat": "^1.6.1",
+    "flat": "^5.0.2",
     "ipaddr.js": "^2.0.1",
     "is-valid-domain": "^0.1.6",
     "leadconduit-integration": "^0.1.0",
@@ -29,7 +29,7 @@
     "soap": "^0.36.0",
     "tlds": "^1.231.0",
     "unidecode": "^0.1.8",
-    "xml2js": "^0.4.16",
+    "xml2js": "^0.5.0",
     "xmlbuilder": "^7.0.0"
   },
   "devDependencies": {

--- a/test/form-spec.js
+++ b/test/form-spec.js
@@ -82,6 +82,15 @@ describe('Outbound Form POST request', function() {
     );
   });
 
+  it('should set redirect-follow option', function() {
+    const vars = {
+      url: 'http://foo.bar'
+    };
+    assert.equal(integration.request(vars).followAllRedirects, false);
+
+    vars.follow_redirects = true;
+    assert.equal(integration.request(vars).followAllRedirects, true);
+  });
 
   it('should support simple dot-notation', function() {
     const vars = {

--- a/test/json-spec.js
+++ b/test/json-spec.js
@@ -74,6 +74,15 @@ describe('Outbound JSON request', function() {
     );
   });
 
+  it('should set redirect-follow option', function() {
+    const vars = {
+      url: 'http://foo.bar'
+    };
+    assert.equal(integration.request(vars).followAllRedirects, false);
+
+    vars.follow_redirects = true;
+    assert.equal(integration.request(vars).followAllRedirects, true);
+  });
 
   it('should support simple dot-notation', function() {
     const vars = {

--- a/test/query-spec.js
+++ b/test/query-spec.js
@@ -62,6 +62,17 @@ describe('Outbound GET Query request', function() {
     assert.equal(integration.request(vars).url, 'http://foo.bar?fname=M%C3%AAl&lname=Gibson');
   });
 
+  it('should set redirect-follow option', function() {
+    const vars = {
+      url: 'http://foo.bar'
+    };
+    // these boolean assertions are the opposite of those for JSON, form, etc.,
+    // because the default for a GET should be true, to follow redirects
+    assert.equal(integration.request(vars).followAllRedirects, true);
+
+    vars.follow_redirects = false;
+    assert.equal(integration.request(vars).followAllRedirects, false);
+  });
 
   it('should support simple dot-notation', function() {
     const vars = {

--- a/test/xml-spec.js
+++ b/test/xml-spec.js
@@ -103,6 +103,15 @@ describe('Outbound XML request', function() {
     );
   });
 
+  it('should set redirect-follow option', function() {
+    const vars = {
+      url: 'http://foo.bar'
+    };
+    assert.equal(integration.request(vars).followAllRedirects, false);
+
+    vars.follow_redirects = true;
+    assert.equal(integration.request(vars).followAllRedirects, true);
+  });
 
   it('should handle empty xml path', function() {
     const vars = {xml_path: {}};


### PR DESCRIPTION
## Description of the change

Adds a new request variable, `follow_redirects`, which in turn sets the `request` library option `followAllRedirects`. When set to "true", it causes `request` to follow 3xx redirects on POST, PUT, etc. 

The default behavior for GETs (i.e., `query`) is to follow redirects; this change also allows a user to change that, by setting the flag to "false".

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/51845/make-custom-integration-able-to-follow-all-redirects

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
