### PR TITLE
sc-61522/bump-flat-to-v5-leadconduit-integration-custom

### DIFF
--- a/lib/xml-doc.js
+++ b/lib/xml-doc.js
@@ -1,26 +1,21 @@
 const _ = require('lodash');
-const flat = require('flat');
+const { flatten } = require('flat');
 const normalize = require('./normalize');
 const compact = require('./compact');
 
 
 //
-// Convert an object into one that can be used by xmlbuilder to create a XML document.
+// Convert an object into one that can be used by xmlbuilder to create an XML document.
 // Keys containing @ are treated as attributes.
 //
 module.exports = function(obj, toAscii = false) {
-  let xmlPaths = flat.flatten(normalize(obj, toAscii) || {});
+  let xmlPaths = flatten(obj || {});
 
   xmlPaths =
     _(xmlPaths)
-
     // Keys that contain neither @ nor # are added as element text
-    .mapKeys(function(value, key) {
-      if (key.match(/@|#/)) {
-        return key;
-      } else {
-        return `${key}#text`;
-      }}).mapKeys((value, key) => key.replace(/(@|#)/, '.$1')).value();
+    .mapKeys((value, key) =>  (key.match(/[@#]/)) ? key: `${key}#text`)
+      .mapKeys((value, key) => key.replace(/([@#])/, '.$1')).value();
 
-  return compact(flat.unflatten(xmlPaths));
+  return compact(normalize(xmlPaths, toAscii));
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "dot-wild": "^3.0.1",
-    "flat": "^1.6.1",
+    "flat": "^5.0.2",
     "ipaddr.js": "^2.0.1",
     "is-valid-domain": "^0.1.6",
     "leadconduit-integration": "^0.1.0",


### PR DESCRIPTION
## Description of the change

> Bump flat v5, move normalization after key modification for xml parsing.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [x] Technical Debt
- [ ] Documentation

## Related tickets

> https://app.shortcut.com/active-prospect/story/61522/bump-flat-to-v5-leadconduit-integration-custom

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut/Jira has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
