### PR TITLE
Sc 85635/error when clicking on first step of lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.23.6] - 2025-01-28
+### Fixed
+- fixed JSON response parsing to wrap numeric keys in quotes ([sc-85635](https://app.shortcut.com/active-prospect/story/85635/error-when-clicking-on-first-step-of-lead-details))
+- minor package updates & a few lint fixes
+
 ## [2.23.4] - 2023-01-30
 ### Added
 - added support for `PATCH` requests for JSON and XML integrations ([sc-47206](https://app.shortcut.com/active-prospect/story/47206/add-support-for-patch-to-custom-integrations))

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,11 +1,38 @@
 const _ = require('lodash');
+const {isPlainObject} = require("lodash");
 const mimecontent = require('mime-content');
 const { parseMimeType } = require('mimeparse');
 const dotWild = require('dot-wild');
 
 const { ensureArray, inverseOutcome, toRegex } = require('./helpers');
 
+/**
+ * Elsewhere in the LeadConduit handler this appended data may go through
+ * the `flat` module's flatten() and/or unflatten(). In cases where this JSON
+ * has numeric keys, especially large ones, this can cause problems as
+ * unflatten() can treat them as array indexes.
+ * E.g., { foo: { 1984: { id: 1984, name: 'Van Halen' } } } could wind up
+ * allocating an array for foo with 1,983 null elements, then that object at
+ * foo[1984]. This function prevents that by forcing those keys to strings:
+ * { foo: { '1984': { id: 1984, name: 'Van Halen' } } }
+ */
+const quoteNumericAttributes = function (obj) {
+  if (!isPlainObject(obj)) { return obj; }
+  const newObj = {};
+  for (let key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const keyAsNumber = Number.parseInt(key);
+      if (Number.isNaN(keyAsNumber)) {
+        newObj[key] = quoteNumericAttributes(obj[key]);
+      } else {
+        newObj[`'${key}'`] = quoteNumericAttributes(obj[key]);
+      }
+    }
+  }
+  return newObj;
+};
 
+/* eslint-disable-next-line complexity */
 const response = function(vars, req, res) {
 
   let cookie, outcome, price;
@@ -128,7 +155,7 @@ const response = function(vars, req, res) {
     catch (error6) {}
   } else if (_.isPlainObject(doc)) {
     // This is a JSON object
-    event = doc;
+    event = quoteNumericAttributes(doc);
   } else if (_.isPlainObject(vars.capture)) {
     // Use any "capture" variables to capture parts of the text into properties from unstructured text
     if (_.isFunction(doc.html)) { doc = doc.html(); }

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const {isPlainObject} = require("lodash");
 const mimecontent = require('mime-content');
 const { parseMimeType } = require('mimeparse');
 const dotWild = require('dot-wild');
@@ -17,7 +16,7 @@ const { ensureArray, inverseOutcome, toRegex } = require('./helpers');
  * { foo: { '1984': { id: 1984, name: 'Van Halen' } } }
  */
 const quoteNumericAttributes = function (obj) {
-  if (!isPlainObject(obj)) { return obj; }
+  if (!_.isPlainObject(obj)) { return obj; }
   const newObj = {};
   for (let key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ipaddr.js": "^2.0.1",
     "is-valid-domain": "^0.1.6",
     "lodash": "^4.0.0",
-    "mime-content": ">=0.0.7",
+    "mime-content": "~0.0.10",
     "mimeparse": "*",
     "private-ip": "^2.3.3",
     "regex-parser": "^2.2.1",
@@ -30,7 +30,7 @@
     "xmlbuilder": "^7.0.0"
   },
   "devDependencies": {
-    "@activeprospect/integration-dev-dependencies": "^1.1.11",
+    "@activeprospect/integration-dev-dependencies": "^2.0.1",
     "leadconduit-types": "^4.5.0"
   }
 }


### PR DESCRIPTION
## Description of the change

Added function to make sure numeric JSON keys are quoted, to prevent their treatment as array indexes by `flat.unflatten()` downstream. Plus a couple of dependency updates and lint fixes.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/85635/error-when-clicking-on-first-step-of-lead-details

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
